### PR TITLE
Ensure NearbyPlayers add/remove operations running on main

### DIFF
--- a/leaf-server/minecraft-patches/features/0336-Ensure-NearbyPlayers-add-remove-operations-running-o.patch
+++ b/leaf-server/minecraft-patches/features/0336-Ensure-NearbyPlayers-add-remove-operations-running-o.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Thu, 4 Mar 2077 00:00:00 +0800
+Subject: [PATCH] Ensure NearbyPlayers add/remove operations running on main
+
+
+diff --git a/ca/spottedleaf/moonrise/common/misc/NearbyPlayers.java b/ca/spottedleaf/moonrise/common/misc/NearbyPlayers.java
+index 499cad369242f9ad724b3251538d62d8dc8d2ec8..5582cfa64da3ba6d451b0c0472820766d066212b 100644
+--- a/ca/spottedleaf/moonrise/common/misc/NearbyPlayers.java
++++ b/ca/spottedleaf/moonrise/common/misc/NearbyPlayers.java
+@@ -190,6 +190,7 @@ public final class NearbyPlayers {
+         }
+ 
+         public void addPlayer(final ServerPlayer player, final NearbyMapType type) {
++            ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread("Add player to NearbyPlayers off-main"); // Leaf - Ensure tick thread
+             ++this.updateCount;
+ 
+             final int idx = type.ordinal();
+@@ -214,6 +215,7 @@ public final class NearbyPlayers {
+         }
+ 
+         public void removePlayer(final ServerPlayer player, final NearbyMapType type) {
++            ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread("Remove player from NearbyPlayers off-main"); // Leaf - Ensure tick thread
+             ++this.updateCount;
+ 
+             final int idx = type.ordinal();


### PR DESCRIPTION
Draft, don't merge.


Current status: Add thread check to locate the root cause