### PR TITLE
async tracker: exclude packets before starting track

### DIFF
--- a/leaf-server/minecraft-patches/features/0277-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0277-Multithreaded-Tracker.patch
@@ -173,7 +173,7 @@ index 349515df48c219896bcf4f0e0479b25b98da002c..0341cc572ee3f627830d074cae30596a
      }
      // CraftBukkit end
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db187d14a85 100644
+index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..2c2ee00a07273bce0c2a3c5e1f30d4535841dfa3 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -1074,6 +1074,13 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -190,7 +190,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
          // Paper start - optimise entity tracker
          if (true) {
              this.newTrackerTick();
-@@ -1224,12 +1231,61 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1224,12 +1231,67 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
          private final Entity entity;
          private final int range;
          private SectionPos lastSectionPos;
@@ -199,6 +199,10 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
 +        public static final ServerPlayerConnection[] EMPTY_OBJECT_ARRAY = new ServerPlayerConnection[0];
 +
 +        private class SeenBySet extends it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<ServerPlayerConnection> {
++            public SeenBySet() {
++                super(4);
++            }
++
 +            @Override
 +            public boolean add(final ServerPlayerConnection serverPlayerConnection) {
 +                if (super.add(serverPlayerConnection)) {
@@ -229,6 +233,8 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
 +        }
 +
 +        public final Set<ServerPlayerConnection> seenBy = org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled ? it.unimi.dsi.fastutil.objects.ReferenceSets.synchronize(new SeenBySet()) : new SeenBySet(); // Paper - Perf: optimise map impl
++        @Nullable
++        public final Set<ServerPlayerConnection> leaf$exclude = org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled ? it.unimi.dsi.fastutil.objects.ReferenceSets.synchronize(new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>(4)) : null;
 +        private volatile boolean seenByUpdated = false;
 +        private volatile ServerPlayerConnection[] seenByArray = EMPTY_OBJECT_ARRAY;
 +        // Used for iteration, copy on updated
@@ -253,7 +259,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
          @Override
          public final void moonrise$tick(final ca.spottedleaf.moonrise.common.misc.NearbyPlayers.TrackedChunk chunk) {
              if (chunk == null) {
-@@ -1239,6 +1295,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1239,6 +1301,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
  
              final ca.spottedleaf.moonrise.common.list.ReferenceList<ServerPlayer> players = chunk.getPlayers(ca.spottedleaf.moonrise.common.misc.NearbyPlayers.NearbyMapType.VIEW_DISTANCE);
  
@@ -261,7 +267,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
              if (players == null) {
                  this.moonrise$clearPlayers();
                  return;
-@@ -1251,27 +1308,35 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1251,27 +1314,35 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              this.lastTrackedChunk = chunk;
  
              final ServerPlayer[] playersRaw = players.getRawDataUnchecked();
@@ -303,7 +309,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
                  if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(conn.getPlayer())) {
                      foundToRemove = true;
                      break;
-@@ -1282,12 +1347,13 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1282,12 +1353,13 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
                  return;
              }
  
@@ -319,7 +325,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
          }
  
          @Override
-@@ -1297,10 +1363,11 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1297,10 +1369,11 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              if (this.seenBy.isEmpty()) {
                  return;
              }
@@ -333,25 +339,36 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
          }
  
          @Override
-@@ -1328,7 +1395,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1328,8 +1401,12 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
  
          @Override
          public void sendToTrackingPlayers(final Packet<? super ClientGamePacketListener> packet) {
 -            for (ServerPlayerConnection connection : this.seenBy) {
-+            for (ServerPlayerConnection connection : this.seenBy()) { // Leaf - petal - Multithreaded tracker
-                 connection.send(packet);
+-                connection.send(packet);
++            for (ServerPlayerConnection connection : this.seenBy()) {
++                // Leaf start - petal - Multithreaded tracker
++                if (this.leaf$exclude != null && !this.leaf$exclude.contains(connection)) {
++                    connection.send(packet);
++                }
++                // Leaf end - petal - Multithreaded tracker
              }
          }
-@@ -1343,7 +1410,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+ 
+@@ -1343,15 +1420,19 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
  
          @Override
          public void sendToTrackingPlayersFiltered(final Packet<? super ClientGamePacketListener> packet, final Predicate<ServerPlayer> targetPredicate) {
 -            for (ServerPlayerConnection connection : this.seenBy) {
-+            for (ServerPlayerConnection connection : this.seenBy()) { // Leaf - petal - Multithreaded tracker
++            for (ServerPlayerConnection connection : this.seenBy()) {
                  if (targetPredicate.test(connection.getPlayer())) {
-                     connection.send(packet);
+-                    connection.send(packet);
++                    // Leaf start - petal - Multithreaded tracker
++                    if (this.leaf$exclude != null && !this.leaf$exclude.contains(connection)) {
++                        connection.send(packet);
++                    }
++                    // Leaf end - petal - Multithreaded tracker
                  }
-@@ -1351,7 +1418,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+             }
          }
  
          public void broadcastRemoved() {
@@ -360,7 +377,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
                  this.serverEntity.removePairing(connection.getPlayer());
              }
          }
-@@ -1360,6 +1427,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1360,6 +1441,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
              if (this.seenBy.remove(player.connection)) {
                  this.serverEntity.removePairing(player);
@@ -368,7 +385,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
                  if (this.seenBy.isEmpty()) {
                      ChunkMap.this.level.debugSynchronizers().dropEntity(this.entity);
                  }
-@@ -1398,6 +1466,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1398,6 +1480,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
                  // CraftBukkit end
                  if (visibleToPlayer) {
                      if (this.seenBy.add(player.connection)) {
@@ -376,7 +393,7 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
                          // Paper start - entity tracking events
                          if (io.papermc.paper.event.player.PlayerTrackEntityEvent.getHandlerList().getRegisteredListeners().length == 0 || new io.papermc.paper.event.player.PlayerTrackEntityEvent(player.getBukkitEntity(), this.entity.getBukkitEntity()).callEvent()) {
                          this.serverEntity.addPairing(player);
-@@ -1411,7 +1480,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1411,7 +1494,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
                          this.serverEntity.onPlayerAdd(); // Paper - fix desync when a player is added to the tracker
                      }
                  } else {
@@ -385,13 +402,16 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
                  }
              }
          }
-@@ -1441,10 +1510,152 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1441,10 +1524,158 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              // Paper end - optimise entity tracker
          }
  
 -        public void updatePlayers(final List<ServerPlayer> players) {
 +        // Leaf start - Multithreaded tracker
 +        public final boolean leaf$tick(final org.dreeam.leaf.async.tracker.TrackerCtx ctx, final ca.spottedleaf.moonrise.common.misc.NearbyPlayers.TrackedChunk chunk) {
++            if (this.leaf$exclude != null) {
++                this.leaf$exclude.clear();
++            }
 +            if (chunk == null || chunk.playersTracking.isEmpty()) {
 +                this.lastChunkUpdate = -1L;
 +                this.lastTrackedChunk = null;
@@ -437,6 +457,9 @@ index 81b8fe00f1edae38f53205b04d15d8cd05ecff36..1e0eceb3ee8b99b5a8cff75687145db1
 +                        && player.getBukkitEntity().canSeeChunkMapUpdatePlayer(this.entity.getBukkitEntity());
 +                    if (flag) {
 +                        if (this.seenBy.add(player.connection)) {
++                            if (this.leaf$exclude != null) {
++                                this.leaf$exclude.add(player.connection);
++                            }
 +                            ctx.startSeenByPlayer(player.connection, this.serverEntity.entity, this.seenBy.size() == 1);
 +                            this.serverEntity.onPlayerAdd();
 +                            updated = true;

--- a/leaf-server/paper-patches/features/0041-Multithreaded-Tracker.patch
+++ b/leaf-server/paper-patches/features/0041-Multithreaded-Tracker.patch
@@ -28,7 +28,7 @@ However we still recommend to use those packet based NPC plugins,
 e.g. ZNPC Plus, Adyeshach, Fancy NPC, etc.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index c185b190a1e545e538681bb7de6068ba974340ba..93eec059109f1e75bea26c0622b75bb30a4b5fc6 100644
+index c185b190a1e545e538681bb7de6068ba974340ba..6c6adb33a922392ed952e36530f1d6a7f5e6fe56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -766,7 +766,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -40,16 +40,22 @@ index c185b190a1e545e538681bb7de6068ba974340ba..93eec059109f1e75bea26c0622b75bb3
                  players.add(connection.getPlayer().getBukkitEntity());
              }
          }
-@@ -1101,7 +1101,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1101,8 +1101,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return;
          }
  
 -        for (final ServerPlayerConnection connection : entityTracker.seenBy) {
+-            this.getHandle().resendPossiblyDesyncedEntityData(connection.getPlayer());
 +        for (final ServerPlayerConnection connection : entityTracker.seenBy()) { // Leaf - Multithreaded tracker
-             this.getHandle().resendPossiblyDesyncedEntityData(connection.getPlayer());
++            // Leaf start - petal - Multithreaded tracker
++            if (entityTracker.leaf$exclude != null && !entityTracker.leaf$exclude.contains(connection)) {
++                this.getHandle().resendPossiblyDesyncedEntityData(connection.getPlayer());
++            }
++            // Leaf end - petal - Multithreaded tracker
          }
      }
-@@ -1247,7 +1247,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+ 
+@@ -1247,7 +1251,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          Set<org.bukkit.entity.Player> set = new java.util.HashSet<>(tracker.seenBy.size());

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
@@ -26,6 +26,7 @@ public final class AsyncTracker {
     public static final int QUEUE = 1024;
     public static final int MIN_CHUNK = 16;
     public static final int THREADS = MultithreadedTracker.threads;
+    @Nullable
     public static final FixedThreadExecutor TRACKER_EXECUTOR = ENABLED ? new FixedThreadExecutor(
         THREADS,
         QUEUE,
@@ -102,7 +103,7 @@ public final class AsyncTracker {
     }
 
     public void onEntitiesTickEnd() {
-        Future<TrackerCtx> @org.jetbrains.annotations.Nullable [] task = this.fut;
+        Future<TrackerCtx>[] task = this.fut;
         TrackerCtx local = this.local;
         if (task == null) {
             return;
@@ -118,7 +119,7 @@ public final class AsyncTracker {
     }
 
     public void onTickEnd() {
-        Future<TrackerCtx> @org.jetbrains.annotations.Nullable [] task = this.fut;
+        Future<TrackerCtx>[] task = this.fut;
         TrackerCtx local = this.local;
         this.fut = null;
         handle(task, local);

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -280,6 +280,9 @@ public final class TrackerCtx {
             connection.send(new ClientboundBundlePacket(list)); // #startTrackingEntity call after #send
             world.debugSynchronizers().startTrackingEntity(player, startSeen.e);
         }
+        if (tracker.leaf$exclude != null) {
+            tracker.leaf$exclude.clear();
+        }
     }
 
     private void handleStopTrack(StopSeen untrack) {


### PR DESCRIPTION
another fix is send packets to packet queue of async tracker