### PR TITLE
Fix persistent enchanting table lapis duplication

### DIFF
--- a/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
+++ b/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
@@ -66,6 +66,148 @@ index 5ba7e9cc6c5966bc845ef03bc3b4485d7a815545..0dec6fbfb08358051b90be97a451b0c8
              // Purpur end - Burp delay - moved to Player#tick()
          }
      }
+diff --git a/net/minecraft/world/inventory/EnchantmentMenu.java b/net/minecraft/world/inventory/EnchantmentMenu.java
+index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5aba9e17c 100644
+--- a/net/minecraft/world/inventory/EnchantmentMenu.java
++++ b/net/minecraft/world/inventory/EnchantmentMenu.java
+@@ -32,6 +32,10 @@ import net.minecraft.world.level.block.EnchantingTableBlock;
+ public class EnchantmentMenu extends AbstractContainerMenu {
+     private static final Identifier EMPTY_SLOT_LAPIS_LAZULI = Identifier.withDefaultNamespace("container/slot/lapis_lazuli");
+     private final Container enchantSlots; // Paper - Add missing InventoryHolders - move down
++    // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++    private final Container clearOnClose;
++    private final Optional<net.minecraft.world.level.block.entity.EnchantingTableBlockEntity> persistentLapisOwner;
++    // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     private final ContainerLevelAccess access;
+     private final RandomSource random = RandomSource.create();
+     private final DataSlot enchantmentSeed = DataSlot.standalone();
+@@ -49,14 +53,44 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+ 
+     public EnchantmentMenu(final int containerId, final Inventory inventory, final ContainerLevelAccess access) {
+         super(MenuType.ENCHANTMENT, containerId);
++        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++        this.persistentLapisOwner = access.evaluate((level, pos) -> {
++            if (level.purpurConfig.enchantmentTableLapisPersists
++                && level.getBlockEntity(pos) instanceof net.minecraft.world.level.block.entity.EnchantingTableBlockEntity enchantmentTable) {
++                return Optional.of(enchantmentTable);
++            }
++            return Optional.empty();
++        }, Optional.empty());
++        if (this.persistentLapisOwner.isPresent()) {
++        final SimpleContainer itemSlot = this.createEnchantSlots(access, 1);
++        // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         // Paper start - Add missing InventoryHolders
+-        this.enchantSlots = new SimpleContainer(this.createBlockHolder(access), 2) { // Paper - Add missing InventoryHolders
+-            @Override
++        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++        this.enchantSlots = new net.minecraft.world.CompoundContainer(itemSlot, this.persistentLapisOwner.get().getLapisContainer()) { // Paper start - Add missing InventoryHolders
++            /*@Override
+             public void setChanged() {
+                 super.setChanged();
+-                EnchantmentMenu.this.slotsChanged(this);
++                EnchantmentMenu.this.enchantSlotsChanged();
++            }*/ // Moved into createEnchantSlots
++
++            @Override
++            public ItemStack removeItem(final int slot, final int count) {
++                final ItemStack removed = super.removeItem(slot, count);
++                if (slot >= itemSlot.getContainerSize() && !removed.isEmpty()) {
++                    EnchantmentMenu.this.enchantSlotsChanged();
++                }
++                return removed;
+             }
+ 
++            @Override
++            public void setItem(final int slot, final ItemStack itemStack) {
++                super.setItem(slot, itemStack);
++                if (slot >= itemSlot.getContainerSize()) {
++                    EnchantmentMenu.this.enchantSlotsChanged();
++                }
++            }
++            // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++            /* // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication // Moved into createEnchantSlots
+             // CraftBukkit start
+             @Override
+             public org.bukkit.Location getLocation() {
+@@ -79,8 +113,16 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+                 }
+             }
+             // Purpur end - Enchantment Table Persists Lapis
++            */ // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         };
+         // Paper end - Add missing InventoryHolders
++        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++        this.clearOnClose = itemSlot;
++        } else {
++            this.enchantSlots = this.createEnchantSlots(access, 2);
++            this.clearOnClose = this.enchantSlots;
++        }
++        // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         this.access = access;
+         this.addSlot(new Slot(this.enchantSlots, 0, 15, 47) {
+             @Override
+@@ -100,14 +142,14 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+             }
+         });
+         // Purpur start - Enchantment Table Persists Lapis
+-        access.execute((level, pos) -> {
++        /*access.execute((level, pos) -> { // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+             if (level.purpurConfig.enchantmentTableLapisPersists) {
+                 net.minecraft.world.level.block.entity.BlockEntity blockEntity = level.getBlockEntity(pos);
+                 if (blockEntity instanceof net.minecraft.world.level.block.entity.EnchantingTableBlockEntity enchantmentTable) {
+                     this.getSlot(1).set(new ItemStack(Items.LAPIS_LAZULI, enchantmentTable.getLapis()));
+                 }
+             }
+-        });
++        });*/ // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         // Purpur end - Enchantment Table Persists Lapis
+         this.addStandardInventorySlots(inventory, 8, 84);
+         this.addDataSlot(DataSlot.shared(this.costs, 0));
+@@ -327,11 +369,17 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+     @Override
+     public void removed(final Player player) {
+         super.removed(player);
+-        this.access.execute((level, pos) -> {if (level.purpurConfig.enchantmentTableLapisPersists) this.getSlot(1).set(ItemStack.EMPTY);this.clearContainer(player, this.enchantSlots);}); // Purpur - Enchantment Table Persists Lapis
++        this.access.execute((level, pos) -> this.clearContainer(player, this.clearOnClose)); // Purpur - Enchantment Table Persists Lapis // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     }
+ 
+     @Override
+     public boolean stillValid(final Player player) {
++        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++        if (this.persistentLapisOwner.isPresent()
++            && !this.access.evaluate((level, pos) -> level.isLoaded(pos) && level.getBlockEntity(pos) == this.persistentLapisOwner.get(), false)) {
++            return false;
++        }
++        // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         if (!this.checkReachable) return true; // CraftBukkit
+         return stillValid(this.access, player, Blocks.ENCHANTING_TABLE);
+     }
+@@ -393,4 +441,25 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+         return this.view;
+     }
+     // CraftBukkit end
++
++    // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++    private SimpleContainer createEnchantSlots(final ContainerLevelAccess access, final int size) {
++        return new SimpleContainer(this.createBlockHolder(access), size) {
++            @Override
++            public void setChanged() {
++                super.setChanged();
++                EnchantmentMenu.this.enchantSlotsChanged();
++            }
++
++            @Override
++            public org.bukkit.Location getLocation() {
++                return access.getLocation();
++            }
++        };
++    }
++
++    private void enchantSlotsChanged() {
++        this.slotsChanged(this.enchantSlots);
++    }
++    // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+ }
 diff --git a/net/minecraft/world/item/FireworkRocketItem.java b/net/minecraft/world/item/FireworkRocketItem.java
 index 3c001b3810097d5cb60ad64e0727d8d9907f6a38..f7d5cba0801b87229fac9d7820aaffadd4ef388c 100644
 --- a/net/minecraft/world/item/FireworkRocketItem.java
@@ -92,6 +234,88 @@ index 7ebf88560e431a07cf4c1417dfd5a71fdd73e557..4542e4cee86158874e034f376da39216
                                  ItemStack glideItem = entity.getItemBySlot(enumitemslot);
                                  if (glideItem.has(net.minecraft.core.component.DataComponents.GLIDER) && level.purpurConfig.elytraDamagePerTridentBoost > 0) {
                                      glideItem.hurtAndBreak(level.purpurConfig.elytraDamagePerTridentBoost, entity, enumitemslot);
+diff --git a/net/minecraft/world/level/block/entity/EnchantingTableBlockEntity.java b/net/minecraft/world/level/block/entity/EnchantingTableBlockEntity.java
+index faadee8259e87e6828b92ec0bbdf69cffdbd4bca..d40220a3e122983002bfe25356bccd62fbae5f0a 100644
+--- a/net/minecraft/world/level/block/entity/EnchantingTableBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/EnchantingTableBlockEntity.java
+@@ -30,7 +30,14 @@ public class EnchantingTableBlockEntity extends BlockEntity implements Nameable
+     public float tRot;
+     private static final RandomSource RANDOM = RandomSource.create();
+     private @Nullable Component name;
+-    private int lapis = 0; // Purpur - Enchantment Table Persists Lapis
++    // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++    private final net.minecraft.world.SimpleContainer lapis = new net.minecraft.world.SimpleContainer(1) {
++        @Override
++        public void setChanged() {
++            EnchantingTableBlockEntity.this.setChanged();
++        }
++    };
++    // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+ 
+     public EnchantingTableBlockEntity(final BlockPos worldPosition, final BlockState blockState) {
+         super(BlockEntityTypes.ENCHANTING_TABLE, worldPosition, blockState);
+@@ -40,14 +47,14 @@ public class EnchantingTableBlockEntity extends BlockEntity implements Nameable
+     protected void saveAdditional(final ValueOutput output) {
+         super.saveAdditional(output);
+         output.storeNullable("CustomName", ComponentSerialization.CODEC, this.name);
+-        output.putInt("Purpur.Lapis", this.lapis); // Purpur - Enchantment Table Persists Lapis
++        output.putInt("Purpur.Lapis", this.getLapis()); // Purpur - Enchantment Table Persists Lapis // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     }
+ 
+     @Override
+     protected void loadAdditional(final ValueInput input) {
+         super.loadAdditional(input);
+         this.name = parseCustomNameSafe(input, "CustomName");
+-        this.lapis = input.getIntOr("Purpur.Lapis", 0); // Purpur - Enchantment Table Persists Lapis
++        this.setLapis(input.getIntOr("Purpur.Lapis", 0), false); // Purpur - Enchantment Table Persists Lapis // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     }
+ 
+     public static void bookAnimationTick(final Level level, final BlockPos worldPosition, final BlockState state, final EnchantingTableBlockEntity entity) {
+@@ -140,20 +147,38 @@ public class EnchantingTableBlockEntity extends BlockEntity implements Nameable
+     }
+ 
+     // Purpur start - Enchantment Table Persists Lapis
++    // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++    public void setLapis(int lapis) {
++        this.setLapis(lapis, true);
++    }
++
++    private void setLapis(int lapis, boolean setChanged) {
++        net.minecraft.world.item.ItemStack stack = lapis > 0
++            ? new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.LAPIS_LAZULI, lapis)
++            : net.minecraft.world.item.ItemStack.EMPTY;
++        if (setChanged) {
++            this.lapis.setItem(0, stack);
++        } else {
++            if (!stack.isEmpty()) {
++                stack.limitSize(this.lapis.getMaxStackSize(stack));
++            }
++            this.lapis.getItems().set(0, stack);
++        }
++    }
++
+     public int getLapis() {
+-        return this.lapis;
++        return this.lapis.getItem(0).getCount();
+     }
+ 
+-    public void setLapis(int lapis) {
+-        this.lapis = lapis;
++    public net.minecraft.world.Container getLapisContainer() {
++        return this.lapis;
+     }
++    // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+ 
+     @Override
+     public void preRemoveSideEffects(BlockPos pos, BlockState state) {
+         super.preRemoveSideEffects(pos, state);
+-        if (this.level != null && this.level.purpurConfig.enchantmentTableLapisPersists) {
+-            net.minecraft.world.Containers.dropItemStack(this.level, pos.getX(), pos.getY(), pos.getZ(), new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.LAPIS_LAZULI, this.getLapis()));
+-        }
++        if (this.level != null) net.minecraft.world.Containers.dropContents(this.level, pos, this.lapis); // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     }
+     // Purpur end - Enchantment Table Persists Lapis
+ }
 diff --git a/org/purpurmc/purpur/PurpurWorldConfig.java b/org/purpurmc/purpur/PurpurWorldConfig.java
 index 922e0efbde69eb7fda111c6a5525c4d700e24f6d..57a4ceac87b7f06d910a778c0022cc142e0538ba 100644
 --- a/org/purpurmc/purpur/PurpurWorldConfig.java

--- a/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
+++ b/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
@@ -67,7 +67,7 @@ index 5ba7e9cc6c5966bc845ef03bc3b4485d7a815545..0dec6fbfb08358051b90be97a451b0c8
          }
      }
 diff --git a/net/minecraft/world/inventory/EnchantmentMenu.java b/net/minecraft/world/inventory/EnchantmentMenu.java
-index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5aba9e17c 100644
+index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd99949711fbddf56 100644
 --- a/net/minecraft/world/inventory/EnchantmentMenu.java
 +++ b/net/minecraft/world/inventory/EnchantmentMenu.java
 @@ -32,6 +32,10 @@ import net.minecraft.world.level.block.EnchantingTableBlock;
@@ -81,7 +81,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
      private final ContainerLevelAccess access;
      private final RandomSource random = RandomSource.create();
      private final DataSlot enchantmentSeed = DataSlot.standalone();
-@@ -49,14 +53,44 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -49,14 +53,47 @@ public class EnchantmentMenu extends AbstractContainerMenu {
  
      public EnchantmentMenu(final int containerId, final Inventory inventory, final ContainerLevelAccess access) {
          super(MenuType.ENCHANTMENT, containerId);
@@ -98,16 +98,17 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
 +        // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
          // Paper start - Add missing InventoryHolders
 -        this.enchantSlots = new SimpleContainer(this.createBlockHolder(access), 2) { // Paper - Add missing InventoryHolders
--            @Override
 +        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
-+        this.enchantSlots = new net.minecraft.world.CompoundContainer(itemSlot, this.persistentLapisOwner.get().getLapisContainer()) { // Paper start - Add missing InventoryHolders
-+            /*@Override
++        this.enchantSlots = new net.minecraft.world.CompoundContainer(itemSlot, this.persistentLapisOwner.get().getLapisContainer()) { // Paper - Add missing InventoryHolders
++            /*
+             @Override
              public void setChanged() {
                  super.setChanged();
--                EnchantmentMenu.this.slotsChanged(this);
-+                EnchantmentMenu.this.enchantSlotsChanged();
-+            }*/ // Moved into createEnchantSlots
-+
+                 EnchantmentMenu.this.slotsChanged(this);
+             }
++            */
++            // Moved into createEnchantSlots
+ 
 +            @Override
 +            public ItemStack removeItem(final int slot, final int count) {
 +                final ItemStack removed = super.removeItem(slot, count);
@@ -115,8 +116,8 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
 +                    EnchantmentMenu.this.enchantSlotsChanged();
 +                }
 +                return removed;
-             }
- 
++            }
++
 +            @Override
 +            public void setItem(final int slot, final ItemStack itemStack) {
 +                super.setItem(slot, itemStack);
@@ -129,7 +130,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
              // CraftBukkit start
              @Override
              public org.bukkit.Location getLocation() {
-@@ -79,8 +113,16 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -79,8 +116,16 @@ public class EnchantmentMenu extends AbstractContainerMenu {
                  }
              }
              // Purpur end - Enchantment Table Persists Lapis
@@ -146,7 +147,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
          this.access = access;
          this.addSlot(new Slot(this.enchantSlots, 0, 15, 47) {
              @Override
-@@ -100,14 +142,14 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -100,14 +145,14 @@ public class EnchantmentMenu extends AbstractContainerMenu {
              }
          });
          // Purpur start - Enchantment Table Persists Lapis
@@ -163,7 +164,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
          // Purpur end - Enchantment Table Persists Lapis
          this.addStandardInventorySlots(inventory, 8, 84);
          this.addDataSlot(DataSlot.shared(this.costs, 0));
-@@ -327,11 +369,17 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -327,11 +372,17 @@ public class EnchantmentMenu extends AbstractContainerMenu {
      @Override
      public void removed(final Player player) {
          super.removed(player);
@@ -182,7 +183,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..fcdae06eb51e66ed4f8a153b52ad67b5
          if (!this.checkReachable) return true; // CraftBukkit
          return stillValid(this.access, player, Blocks.ENCHANTING_TABLE);
      }
-@@ -393,4 +441,25 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -393,4 +444,25 @@ public class EnchantmentMenu extends AbstractContainerMenu {
          return this.view;
      }
      // CraftBukkit end

--- a/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
+++ b/leaf-server/minecraft-patches/features/0083-Fix-Pufferfish-and-Purpur-patches.patch
@@ -67,7 +67,7 @@ index 5ba7e9cc6c5966bc845ef03bc3b4485d7a815545..0dec6fbfb08358051b90be97a451b0c8
          }
      }
 diff --git a/net/minecraft/world/inventory/EnchantmentMenu.java b/net/minecraft/world/inventory/EnchantmentMenu.java
-index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd99949711fbddf56 100644
+index 842426534c9516067d95fce5183daa0279e0f488..92b0a0010d44f19f2f8d2efacc078b37640e3b6e 100644
 --- a/net/minecraft/world/inventory/EnchantmentMenu.java
 +++ b/net/minecraft/world/inventory/EnchantmentMenu.java
 @@ -32,6 +32,10 @@ import net.minecraft.world.level.block.EnchantingTableBlock;
@@ -81,13 +81,18 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
      private final ContainerLevelAccess access;
      private final RandomSource random = RandomSource.create();
      private final DataSlot enchantmentSeed = DataSlot.standalone();
-@@ -49,14 +53,47 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -48,15 +52,57 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+     }
  
      public EnchantmentMenu(final int containerId, final Inventory inventory, final ContainerLevelAccess access) {
++        this(containerId, inventory, access, true); // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++    }
++
++    public EnchantmentMenu(final int containerId, final Inventory inventory, final ContainerLevelAccess access, final boolean bindPersistentLapis) { // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
          super(MenuType.ENCHANTMENT, containerId);
 +        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
 +        this.persistentLapisOwner = access.evaluate((level, pos) -> {
-+            if (level.purpurConfig.enchantmentTableLapisPersists
++            if (bindPersistentLapis && level.purpurConfig.enchantmentTableLapisPersists
 +                && level.getBlockEntity(pos) instanceof net.minecraft.world.level.block.entity.EnchantingTableBlockEntity enchantmentTable) {
 +                return Optional.of(enchantmentTable);
 +            }
@@ -108,7 +113,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
              }
 +            */
 +            // Moved into createEnchantSlots
- 
++
 +            @Override
 +            public ItemStack removeItem(final int slot, final int count) {
 +                final ItemStack removed = super.removeItem(slot, count);
@@ -125,12 +130,17 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
 +                    EnchantmentMenu.this.enchantSlotsChanged();
 +                }
 +            }
+ 
++            @Override
++            public org.bukkit.inventory.@org.jspecify.annotations.Nullable InventoryHolder getOwner() {
++                return itemSlot.getOwner();
++            }
 +            // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
 +            /* // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication // Moved into createEnchantSlots
              // CraftBukkit start
              @Override
              public org.bukkit.Location getLocation() {
-@@ -79,8 +116,16 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -79,8 +125,16 @@ public class EnchantmentMenu extends AbstractContainerMenu {
                  }
              }
              // Purpur end - Enchantment Table Persists Lapis
@@ -147,7 +157,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
          this.access = access;
          this.addSlot(new Slot(this.enchantSlots, 0, 15, 47) {
              @Override
-@@ -100,14 +145,14 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -100,14 +154,14 @@ public class EnchantmentMenu extends AbstractContainerMenu {
              }
          });
          // Purpur start - Enchantment Table Persists Lapis
@@ -164,7 +174,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
          // Purpur end - Enchantment Table Persists Lapis
          this.addStandardInventorySlots(inventory, 8, 84);
          this.addDataSlot(DataSlot.shared(this.costs, 0));
-@@ -327,11 +372,17 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -327,11 +381,17 @@ public class EnchantmentMenu extends AbstractContainerMenu {
      @Override
      public void removed(final Player player) {
          super.removed(player);
@@ -183,7 +193,7 @@ index 842426534c9516067d95fce5183daa0279e0f488..ad2f41b16f848a87e91b16ecd9994971
          if (!this.checkReachable) return true; // CraftBukkit
          return stillValid(this.access, player, Blocks.ENCHANTING_TABLE);
      }
-@@ -393,4 +444,25 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+@@ -393,4 +453,25 @@ public class EnchantmentMenu extends AbstractContainerMenu {
          return this.view;
      }
      // CraftBukkit end

--- a/leaf-server/paper-patches/features/0068-Fix-Pufferfish-and-Purpur-patches.patch
+++ b/leaf-server/paper-patches/features/0068-Fix-Pufferfish-and-Purpur-patches.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
+Date: Mon, 29 Apr 2024 14:18:58 -0400
+Subject: [PATCH] Fix Pufferfish and Purpur patches
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index 374d39057f4913ff9586205ee2cf305a99279bae..9efc174b48afe8548f5be11805c334e50173cf4d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -424,14 +424,16 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         BlockPos pos = CraftLocation.toBlockPos(location);
+         // Paper start
+         MenuProvider menuProvider = Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos);
+-        if (menuProvider == null) {
+-            if (!force) {
+-                return null;
+-            }
++        // Leaf start - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
++        if (force) {
++            Component title = menuProvider == null ? Component.translatable("container.enchant") : menuProvider.getDisplayName();
+             menuProvider = new net.minecraft.world.SimpleMenuProvider((syncId, inventory, player) -> {
+-                return new net.minecraft.world.inventory.EnchantmentMenu(syncId, inventory, net.minecraft.world.inventory.ContainerLevelAccess.create(this.getHandle().level(), pos));
+-            }, Component.translatable("container.enchant"));
++                return new net.minecraft.world.inventory.EnchantmentMenu(syncId, inventory, net.minecraft.world.inventory.ContainerLevelAccess.create(this.getHandle().level(), pos), false);
++            }, title);
++        } else if (menuProvider == null) {
++            return null;
+         }
++        // Leaf end - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         this.getHandle().openMenu(menuProvider);
+         // Paper end
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftEnchantmentInventoryViewBuilder.java b/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftEnchantmentInventoryViewBuilder.java
+index 6f502941596a0f909d28d85356373fea6adb7539..518339cf7f7e1b088c8f7209bef7c0120c400ddc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftEnchantmentInventoryViewBuilder.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/view/builder/CraftEnchantmentInventoryViewBuilder.java
+@@ -25,7 +25,7 @@ public class CraftEnchantmentInventoryViewBuilder extends CraftAbstractLocationI
+         if (this.position == null) {
+             this.position = player.blockPosition();
+             super.defaultTitle = new EnchantingTableBlockEntity(this.position, Blocks.ENCHANTING_TABLE.defaultBlockState()).getDisplayName();
+-            return new EnchantmentMenu(player.nextContainerCounter(), player.getInventory(), ContainerLevelAccess.create(this.world, this.position));
++            return new EnchantmentMenu(player.nextContainerCounter(), player.getInventory(), ContainerLevelAccess.create(this.world, this.position), this.checkReachable); // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+         }
+ 
+         final BlockEntity entity = this.world.getBlockEntity(position);
+@@ -35,6 +35,6 @@ public class CraftEnchantmentInventoryViewBuilder extends CraftAbstractLocationI
+             super.defaultTitle = new EnchantingTableBlockEntity(this.position, Blocks.ENCHANTING_TABLE.defaultBlockState()).getDisplayName();
+         }
+ 
+-        return new EnchantmentMenu(player.nextContainerCounter(), player.getInventory(), ContainerLevelAccess.create(this.world, this.position));
++        return new EnchantmentMenu(player.nextContainerCounter(), player.getInventory(), ContainerLevelAccess.create(this.world, this.position), this.checkReachable); // Leaf - Fix Pufferfish and Purpur patches - Fix persistent enchanting table lapis duplication
+     }
+ }


### PR DESCRIPTION
Purpur's implementation will dupe lapis when multiple players open the same enchanting table, this PR fixed by making EnchantingTableBlockEntity hold the shared lapis container, this will automatically sync among players