### PR TITLE
Add dense section push index

### DIFF
--- a/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
+++ b/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
@@ -18,7 +18,7 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
-index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..f3ccc1cd38759efebb821f9d0e16dd3e7283f1e1 100644
+index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106403f0eb5 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 @@ -339,6 +339,12 @@ public final class ChunkEntitySlices {
@@ -34,7 +34,27 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..f3ccc1cd38759efebb821f9d0e16dd3e
      public boolean getEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate,
                                 final int maxCount) {
          return this.allEntities.getEntitiesLimited(except, box, into, predicate, maxCount);
-@@ -660,5 +666,148 @@ public final class ChunkEntitySlices {
+@@ -528,6 +534,9 @@ public final class ChunkEntitySlices {
+ 
+             list.add(entity);
+             ++this.count;
++            // Leaf start - dense section push index
++            this.invalidateDenseGrid(sectionIndex);
++            // Leaf end - dense section push index
+         }
+ 
+         public void removeEntity(final Entity entity, final int sectionIndex) {
+@@ -542,6 +551,9 @@ public final class ChunkEntitySlices {
+             if (list.isEmpty()) {
+                 this.entitiesBySection[sectionIndex] = null;
+             }
++            // Leaf start - dense section push index
++            this.invalidateDenseGrid(sectionIndex);
++            // Leaf end - dense section push index
+         }
+ 
+         public void getEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate) {
+@@ -660,5 +672,154 @@ public final class ChunkEntitySlices {
  
              return false;
          }
@@ -109,6 +129,12 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..f3ccc1cd38759efebb821f9d0e16dd3e
 +
 +        private static long denseKey(final int x, final int y, final int z) {
 +            return (((long) x & 0x1FFFFFL) << 42) | (((long) y & 0xFFFFFL) << 21) | ((long) z & 0x1FFFFFL);
++        }
++
++        private void invalidateDenseGrid(final int sectionIndex) {
++            if (sectionIndex < this.denseGrids.size()) {
++                this.denseGrids.set(sectionIndex, null);
++            }
 +        }
 +
 +        private boolean forEachEntityDense(final int sectionIndex, final BasicEntityList<Entity> list, final Entity except,

--- a/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
+++ b/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
@@ -18,7 +18,7 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
-index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd469cba9b1 100644
+index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..f3ccc1cd38759efebb821f9d0e16dd3e7283f1e1 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 @@ -339,6 +339,12 @@ public final class ChunkEntitySlices {
@@ -34,7 +34,7 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd4
      public boolean getEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate,
                                 final int maxCount) {
          return this.allEntities.getEntitiesLimited(except, box, into, predicate, maxCount);
-@@ -660,5 +666,59 @@ public final class ChunkEntitySlices {
+@@ -660,5 +666,148 @@ public final class ChunkEntitySlices {
  
              return false;
          }
@@ -66,6 +66,16 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd4
 +                    continue;
 +                }
 +
++                // Leaf start - dense section push index
++                if (org.dreeam.leaf.config.modules.opt.DenseSectionPushIndex.enabled
++                    && list.size() > org.dreeam.leaf.config.modules.opt.DenseSectionPushIndex.threshold) {
++                    if (this.forEachEntityDense(section - minSection, list, except, box, predicate, consumer)) {
++                        return true;
++                    }
++                    continue;
++                }
++                // Leaf end - dense section push index
++
 +                final Entity[] storage = list.storage;
 +
 +                for (int i = 0, len = Math.min(storage.length, list.size()); i < len; ++i) {
@@ -92,6 +102,85 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd4
 +            return false;
 +        }
 +        // Leaf end - Limit pushable entity queries
++
++        // Leaf start - dense section push index
++        private final java.util.List<it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<java.util.ArrayList<Entity>>> denseGrids = new java.util.ArrayList<>();
++        private long denseGridsTick = Long.MIN_VALUE;
++
++        private static long denseKey(final int x, final int y, final int z) {
++            return (((long) x & 0x1FFFFFL) << 42) | (((long) y & 0xFFFFFL) << 21) | ((long) z & 0x1FFFFFL);
++        }
++
++        private boolean forEachEntityDense(final int sectionIndex, final BasicEntityList<Entity> list, final Entity except,
++                                            final AABB box, final Predicate<? super Entity> predicate,
++                                            final net.minecraft.util.AbortableIterationConsumer<Entity> consumer) {
++            final long currentTick = net.minecraft.server.MinecraftServer.currentTick;
++            if (currentTick != this.denseGridsTick) {
++                this.denseGrids.clear();
++                this.denseGridsTick = currentTick;
++            }
++            while (this.denseGrids.size() <= sectionIndex) {
++                this.denseGrids.add(null);
++            }
++
++            it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<java.util.ArrayList<Entity>> grid = this.denseGrids.get(sectionIndex);
++            if (grid == null) {
++                grid = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>(list.size() * 2);
++                final Entity[] storage = list.storage;
++                for (int i = 0, len = Math.min(storage.length, list.size()); i < len; ++i) {
++                    final Entity entity = storage[i];
++                    if (entity == null) {
++                        continue;
++                    }
++                    final AABB bb = entity.getBoundingBox();
++                    final int minBX = Mth.floor(bb.minX), maxBX = Mth.floor(bb.maxX - 1.0E-7);
++                    final int minBY = Mth.floor(bb.minY), maxBY = Mth.floor(bb.maxY - 1.0E-7);
++                    final int minBZ = Mth.floor(bb.minZ), maxBZ = Mth.floor(bb.maxZ - 1.0E-7);
++                    for (int bx = minBX; bx <= maxBX; ++bx) {
++                        for (int by = minBY; by <= maxBY; ++by) {
++                            for (int bz = minBZ; bz <= maxBZ; ++bz) {
++                                grid.computeIfAbsent(denseKey(bx, by, bz), k -> new java.util.ArrayList<>(2)).add(entity);
++                            }
++                        }
++                    }
++                }
++                this.denseGrids.set(sectionIndex, grid);
++            }
++
++            final int minBX = Mth.floor(box.minX), maxBX = Mth.floor(box.maxX - 1.0E-7);
++            final int minBY = Mth.floor(box.minY), maxBY = Mth.floor(box.maxY - 1.0E-7);
++            final int minBZ = Mth.floor(box.minZ), maxBZ = Mth.floor(box.maxZ - 1.0E-7);
++            // dedupes cross-cell entities
++            final it.unimi.dsi.fastutil.ints.IntOpenHashSet seen = new it.unimi.dsi.fastutil.ints.IntOpenHashSet();
++            for (int bx = minBX; bx <= maxBX; ++bx) {
++                for (int by = minBY; by <= maxBY; ++by) {
++                    for (int bz = minBZ; bz <= maxBZ; ++bz) {
++                        final java.util.ArrayList<Entity> cell = grid.get(denseKey(bx, by, bz));
++                        if (cell == null) {
++                            continue;
++                        }
++                        for (int i = 0, len = cell.size(); i < len; ++i) {
++                            final Entity entity = cell.get(i);
++                            if (entity == except || !seen.add(entity.getId())) {
++                                continue;
++                            }
++                            final AABB entityBB = entity.getBoundingBox();
++                            if (entityBB.maxX <= box.minX || entityBB.minX >= box.maxX || entityBB.maxY <= box.minY || entityBB.minY >= box.maxY || entityBB.maxZ <= box.minZ || entityBB.minZ >= box.maxZ) {
++                                continue;
++                            }
++                            if (predicate != null && !predicate.test(entity)) {
++                                continue;
++                            }
++                            if (consumer.accept(entity).shouldAbort()) {
++                                return true;
++                            }
++                        }
++                    }
++                }
++            }
++            return false;
++        }
++        // Leaf end - dense section push index
      }
  }
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java

--- a/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
+++ b/leaf-server/minecraft-patches/features/0325-Limit-pushable-entity-queries.patch
@@ -18,7 +18,7 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
-index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106403f0eb5 100644
+index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..5808a0f4403085850e7bb05781e650e183839545 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 @@ -339,6 +339,12 @@ public final class ChunkEntitySlices {
@@ -34,6 +34,15 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106
      public boolean getEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate,
                                 final int maxCount) {
          return this.allEntities.getEntitiesLimited(except, box, into, predicate, maxCount);
+@@ -501,7 +507,7 @@ public final class ChunkEntitySlices {
+         }
+     }
+ 
+-    private static final class EntityCollectionBySection {
++    private static final class EntityCollectionBySection implements org.dreeam.leaf.world.DenseGridOwner {
+ 
+         private final ChunkEntitySlices slices;
+         private final BasicEntityList<Entity>[] entitiesBySection;
 @@ -528,6 +534,9 @@ public final class ChunkEntitySlices {
  
              list.add(entity);
@@ -54,7 +63,7 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106
          }
  
          public void getEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate) {
-@@ -660,5 +672,154 @@ public final class ChunkEntitySlices {
+@@ -660,5 +672,157 @@ public final class ChunkEntitySlices {
  
              return false;
          }
@@ -131,7 +140,8 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106
 +            return (((long) x & 0x1FFFFFL) << 42) | (((long) y & 0xFFFFFL) << 21) | ((long) z & 0x1FFFFFL);
 +        }
 +
-+        private void invalidateDenseGrid(final int sectionIndex) {
++        @Override
++        public void invalidateDenseGrid(final int sectionIndex) {
 +            if (sectionIndex < this.denseGrids.size()) {
 +                this.denseGrids.set(sectionIndex, null);
 +            }
@@ -158,6 +168,8 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..85c514b756ed43cd338da32b5ac13106
 +                    if (entity == null) {
 +                        continue;
 +                    }
++                    entity.leaf$denseGridOwner = this;
++                    entity.leaf$denseGridSectionIndex = sectionIndex;
 +                    final AABB bb = entity.getBoundingBox();
 +                    final int minBX = Mth.floor(bb.minX), maxBX = Mth.floor(bb.maxX - 1.0E-7);
 +                    final int minBY = Mth.floor(bb.minY), maxBY = Mth.floor(bb.maxY - 1.0E-7);
@@ -261,6 +273,34 @@ index 775bea1ff010d3bdd6ea20ad47d9b8c45fbdc95f..2a9032f8fe5424d3795093dfa8bd79ef
      public void getHardCollidingEntities(final Entity except, final AABB box, final List<Entity> into, final Predicate<? super Entity> predicate) {
          final int minChunkX = (Mth.floor(box.minX) - 2) >> 4;
          final int minChunkZ = (Mth.floor(box.minZ) - 2) >> 4;
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index 650a382301321196b5f547f500869f2906311260..beeaefbd2a3b34b7830a682667a9dc9bca05aedd 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -392,6 +392,10 @@ public abstract class Entity
+     public final io.papermc.paper.entity.activation.ActivationType activationType = io.papermc.paper.entity.activation.ActivationType.activationTypeFor(this); // Paper - EAR 2/tracking ranges
+     public @Nullable Boolean immuneToFire = null; // Purpur - Fire immune API
+     public boolean leaf$isWeakLoaded = false; // Leaf - Rewrite entity despawn time
++    // Leaf start - dense section push index
++    public org.dreeam.leaf.world.DenseGridOwner leaf$denseGridOwner;
++    public int leaf$denseGridSectionIndex;
++    // Leaf end - dense section push index
+     protected boolean preventMoveIntoWeakLoadedChunks = false; // Leaf - Prevent entity from moving into weak loaded chunks
+     // Paper start - EAR 2
+     public final boolean defaultActivationState;
+@@ -4821,6 +4825,12 @@ public abstract class Entity
+         // Gale start - VMP - skip entity move if movement is zero
+         if (!this.bb.equals(bb)) {
+             this.boundingBoxChanged = true;
++            // Leaf start - dense section push index
++            if (this.leaf$denseGridOwner != null) {
++                this.leaf$denseGridOwner.invalidateDenseGrid(this.leaf$denseGridSectionIndex);
++                this.leaf$denseGridOwner = null;
++            }
++            // Leaf end - dense section push index
+         }
+         // Gale end - VMP - skip entity move if movement is zero
+         // CraftBukkit start - block invalid bounding boxes
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
 index af775113bebde3b49ded7d870e75419514b6e361..14cf550c114df95fd43a5e002715c34e92be3c2a 100644
 --- a/net/minecraft/world/entity/LivingEntity.java

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
@@ -18,11 +18,10 @@ public class DenseSectionPushIndex extends ConfigModule {
     public void onLoaded() {
         globalConfig.addCommentRegionBased(basePath(), """
                 Index entities by block position instead of scanning the whole section
-                when a section has more than `threshold` entities in it (e.g. a dense
-                mob farm). Speeds up pushEntities()/entity-cramming checks in that case.""",
+                when a section has more than `threshold` entities in it.""",
             """
-                当一个 section 内实体数超过 threshold 时（例如密集刷怪场）,
-                按方块坐标建索引代替全量扫描, 加速推挤/挤压伤害检测.""");
+                当一个 section 内实体数超过 threshold 时,
+                按方块坐标建索引代替全量扫描.""");
 
         enabled = globalConfig.getBoolean(basePath() + ".enabled", enabled);
         threshold = globalConfig.getInt(basePath() + ".threshold", threshold);

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
@@ -1,0 +1,30 @@
+package org.dreeam.leaf.config.modules.opt;
+
+import org.dreeam.leaf.config.ConfigModule;
+import org.dreeam.leaf.config.ConfigCategory;
+import org.dreeam.leaf.config.annotations.Experimental;
+
+public class DenseSectionPushIndex extends ConfigModule {
+
+    public String basePath() {
+        return ConfigCategory.PERF.basePath() + ".dense-section-push-index";
+    }
+
+    @Experimental
+    public static boolean enabled = false;
+    public static int threshold = 300;
+
+    @Override
+    public void onLoaded() {
+        globalConfig.addCommentRegionBased(basePath(), """
+                Index entities by block position instead of scanning the whole section
+                when a section has more than `threshold` entities in it (e.g. a dense
+                mob farm). Speeds up pushEntities()/entity-cramming checks in that case.""",
+            """
+                当一个 section 内实体数超过 threshold 时（例如密集刷怪场）,
+                按方块坐标建索引代替全量扫描, 加速推挤/挤压伤害检测.""");
+
+        enabled = globalConfig.getBoolean(basePath() + ".enabled", enabled);
+        threshold = globalConfig.getInt(basePath() + ".threshold", threshold);
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/DenseSectionPushIndex.java
@@ -12,7 +12,7 @@ public class DenseSectionPushIndex extends ConfigModule {
 
     @Experimental
     public static boolean enabled = false;
-    public static int threshold = 300;
+    public static int threshold = 64;
 
     @Override
     public void onLoaded() {

--- a/leaf-server/src/main/java/org/dreeam/leaf/world/DenseGridOwner.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/DenseGridOwner.java
@@ -1,0 +1,5 @@
+package org.dreeam.leaf.world;
+
+public interface DenseGridOwner {
+    void invalidateDenseGrid(int sectionIndex);
+}


### PR DESCRIPTION
`LivingEntity.pushEntities()`（推挤/挤压伤害检测）在实体扎堆（潜影贝farm 那类场景）时的性能问题

试过网格分区、Sweep-and-Prune、增量 SAP、BVH 树几种方案，唯独 block-hash 索引是规模越大赢得越多、没有反常输的区间（其它方案在某些聚集程度或规模下会反而更慢[实际验证表明]）。跟原版对比、跟 SAP 对比都测过边界：约 N=200\~300 是拐点，往下用原来的线性扫描更划算（避免 HashMap 的固定开销），往上 hash 索引稳赢，且优势随 N 单调扩大（实测 15x~38x）。