### PR TITLE
Fix bookshelf item loss with use-vanilla-hopper

### DIFF
--- a/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
+++ b/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
@@ -9,10 +9,10 @@ Original project: https://github.com/LeavesMC/Leaves
 This is a temporary solution designed to attempt to restore the vanilla behavior of the funnel while preserving optimizations as much as possible. It should ultimately be replaced by the optimization solution provided by lithium.
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index dab2778068afa42ad8719300852b4ac8495a2a09..c7129e606dc44dd3d4928c46e29d0636dea2ca22 100644
+index dab2778068afa42ad8719300852b4ac8495a2a09..c3b9880f125aee88f671f5e527043676b70bca4a 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -281,36 +281,68 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -281,36 +281,70 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          ItemStack movedItem = origItemStack;
          final int originalItemCount = origItemStack.getCount();
          final int movedItemCount = Math.min(level.spigotConfig.hopperAmount, originalItemCount);
@@ -35,7 +35,9 @@ index dab2778068afa42ad8719300852b4ac8495a2a09..c7129e606dc44dd3d4928c46e29d0636
 +            final boolean removeOriginalItem = movedItem == origItemStack;
 +            if (removeOriginalItem) {
 +                movedItem = container.removeItem(i, movedItemCount);
-+                movedItem = movedItem.copy(true); // copy if reference equal
++                if (movedItem == origItemStack) {
++                    movedItem = movedItem.copy(true); // copy if reference equal
++                }
 +            }
  
 -        if (!skipPullModeEventFire) {

--- a/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
+++ b/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
@@ -9,7 +9,7 @@ Original project: https://github.com/LeavesMC/Leaves
 This is a temporary solution designed to attempt to restore the vanilla behavior of the funnel while preserving optimizations as much as possible. It should ultimately be replaced by the optimization solution provided by lithium.
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index dab2778068afa42ad8719300852b4ac8495a2a09..b309946226f214ac2013667e5b0fce2257229475 100644
+index dab2778068afa42ad8719300852b4ac8495a2a09..c7129e606dc44dd3d4928c46e29d0636dea2ca22 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -281,36 +281,68 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
@@ -35,7 +35,7 @@ index dab2778068afa42ad8719300852b4ac8495a2a09..b309946226f214ac2013667e5b0fce22
 +            final boolean removeOriginalItem = movedItem == origItemStack;
 +            if (removeOriginalItem) {
 +                movedItem = container.removeItem(i, movedItemCount);
-+                movedItem = movedItem.copy(true); // Leaf - avoid write-back clearing the inserted stack (aliased removeItem)
++                movedItem = movedItem.copy(true); // copy if reference equal
 +            }
  
 -        if (!skipPullModeEventFire) {

--- a/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
+++ b/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
@@ -9,10 +9,10 @@ Original project: https://github.com/LeavesMC/Leaves
 This is a temporary solution designed to attempt to restore the vanilla behavior of the funnel while preserving optimizations as much as possible. It should ultimately be replaced by the optimization solution provided by lithium.
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index dab2778068afa42ad8719300852b4ac8495a2a09..e1cf1057e9dd6cc859621d791ec62bbb2bcff04b 100644
+index dab2778068afa42ad8719300852b4ac8495a2a09..ea0cb436d42980ba996adfd660430e167e7c8324 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -281,36 +281,67 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -281,36 +281,73 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          ItemStack movedItem = origItemStack;
          final int originalItemCount = origItemStack.getCount();
          final int movedItemCount = Math.min(level.spigotConfig.hopperAmount, originalItemCount);
@@ -46,6 +46,12 @@ index dab2778068afa42ad8719300852b4ac8495a2a09..e1cf1057e9dd6cc859621d791ec62bbb
 -                // site for IMIE did not exhibit the same behavior
 +            final int itemCountToMove = movedItem.getCount();
 +            final ItemStack remainingItem = addItem(container, hopper, movedItem, null);
++            // Leaf start - fix aliased item loss (e.g. chiseled bookshelf)
++            if (removeOriginalItem && remainingItem.isEmpty()) {
++                container.setChanged();
++                return true;
++            }
++            // Leaf end - fix aliased item loss (e.g. chiseled bookshelf)
 +            if (remainingItem.getCount() != itemCountToMove) {
 +                origItemStack.setCount(removeOriginalItem ? originalItemCount - movedItemCount : originalItemCount);
 +                container.setItem(i, origItemStack);

--- a/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
+++ b/leaf-server/minecraft-patches/features/0305-Leaves-Vanilla-hopper.patch
@@ -9,10 +9,10 @@ Original project: https://github.com/LeavesMC/Leaves
 This is a temporary solution designed to attempt to restore the vanilla behavior of the funnel while preserving optimizations as much as possible. It should ultimately be replaced by the optimization solution provided by lithium.
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index dab2778068afa42ad8719300852b4ac8495a2a09..ea0cb436d42980ba996adfd660430e167e7c8324 100644
+index dab2778068afa42ad8719300852b4ac8495a2a09..b309946226f214ac2013667e5b0fce2257229475 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -281,36 +281,73 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -281,36 +281,68 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          ItemStack movedItem = origItemStack;
          final int originalItemCount = origItemStack.getCount();
          final int movedItemCount = Math.min(level.spigotConfig.hopperAmount, originalItemCount);
@@ -35,6 +35,7 @@ index dab2778068afa42ad8719300852b4ac8495a2a09..ea0cb436d42980ba996adfd660430e16
 +            final boolean removeOriginalItem = movedItem == origItemStack;
 +            if (removeOriginalItem) {
 +                movedItem = container.removeItem(i, movedItemCount);
++                movedItem = movedItem.copy(true); // Leaf - avoid write-back clearing the inserted stack (aliased removeItem)
 +            }
  
 -        if (!skipPullModeEventFire) {
@@ -46,12 +47,6 @@ index dab2778068afa42ad8719300852b4ac8495a2a09..ea0cb436d42980ba996adfd660430e16
 -                // site for IMIE did not exhibit the same behavior
 +            final int itemCountToMove = movedItem.getCount();
 +            final ItemStack remainingItem = addItem(container, hopper, movedItem, null);
-+            // Leaf start - fix aliased item loss (e.g. chiseled bookshelf)
-+            if (removeOriginalItem && remainingItem.isEmpty()) {
-+                container.setChanged();
-+                return true;
-+            }
-+            // Leaf end - fix aliased item loss (e.g. chiseled bookshelf)
 +            if (remainingItem.getCount() != itemCountToMove) {
 +                origItemStack.setCount(removeOriginalItem ? originalItemCount - movedItemCount : originalItemCount);
 +                container.setItem(i, origItemStack);

--- a/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
+++ b/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Replace Lithium tracker list with array
 
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f05b5f7bf 100644
+index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f3eaa05c4 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -875,21 +875,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -870,21 +870,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      //Mod count used to avoid transfer attempts that are known to fail (no change since last attempt)
      private long insertStackListModCount, extractStackListModCount;
  
@@ -33,7 +33,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
      @Nullable
      private AABB insertInventoryEntityBox;
      private long insertInventoryEntityFailedSearchTime;
-@@ -971,19 +968,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -966,19 +963,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
              ((net.caffeinemc.mods.lithium.common.block.entity.inventory_change_tracking.InventoryChangeTracker) this.insertBlockInventory).listenForContentChangesOnce(this.insertStackList, this);
          }
          if (listenToInsertEntities) {
@@ -56,7 +56,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
                  return;
              }
              net.caffeinemc.mods.lithium.common.tracking.entity.ChunkSectionEntityMovementTracker.listenToEntityMovementOnce(this, collectItemEntityTracker);
-@@ -1118,7 +1115,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1113,7 +1110,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateInsertionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.insertInventoryEntityTracker != null) {
@@ -65,7 +65,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
                  this.insertInventoryEntityTracker = null;
                  this.insertInventoryEntityBox = null;
                  this.insertInventoryEntityFailedSearchTime = 0L;
-@@ -1146,13 +1143,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1141,13 +1138,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateExtractionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.extractInventoryEntityTracker != null) {
@@ -81,7 +81,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
                  this.collectItemEntityTracker = null;
                  this.collectItemEntityBox = null;
                  this.collectItemEntityTrackerWasEmpty = false;
-@@ -1288,7 +1285,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1283,7 +1280,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.insertInventoryEntityTracker == null) {
              this.initInsertInventoryTracker(world);
          }
@@ -90,7 +90,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
              this.insertInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1353,7 +1350,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1348,7 +1345,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.extractInventoryEntityTracker == null) {
              this.initExtractInventoryTracker(level);
          }
@@ -99,7 +99,7 @@ index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f
              this.extractInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1473,7 +1470,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1468,7 +1465,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          long modCount = net.caffeinemc.mods.lithium.common.hopper.InventoryHelper.getLithiumStackList(hopperBlockEntity).getModCount();
  
          if ((hopperBlockEntity.collectItemEntityTrackerWasEmpty || hopperBlockEntity.myModCountAtLastItemCollect == modCount) &&

--- a/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
+++ b/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Replace Lithium tracker list with array
 
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec385192a46f4f 100644
+index ea0cb436d42980ba996adfd660430e167e7c8324..7ef954494de911a26cfad9f6db94513f05b5f7bf 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -869,21 +869,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -875,21 +875,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      //Mod count used to avoid transfer attempts that are known to fail (no change since last attempt)
      private long insertStackListModCount, extractStackListModCount;
  
@@ -33,7 +33,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
      @Nullable
      private AABB insertInventoryEntityBox;
      private long insertInventoryEntityFailedSearchTime;
-@@ -965,19 +962,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -971,19 +968,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
              ((net.caffeinemc.mods.lithium.common.block.entity.inventory_change_tracking.InventoryChangeTracker) this.insertBlockInventory).listenForContentChangesOnce(this.insertStackList, this);
          }
          if (listenToInsertEntities) {
@@ -56,7 +56,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
                  return;
              }
              net.caffeinemc.mods.lithium.common.tracking.entity.ChunkSectionEntityMovementTracker.listenToEntityMovementOnce(this, collectItemEntityTracker);
-@@ -1112,7 +1109,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1118,7 +1115,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateInsertionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.insertInventoryEntityTracker != null) {
@@ -65,7 +65,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
                  this.insertInventoryEntityTracker = null;
                  this.insertInventoryEntityBox = null;
                  this.insertInventoryEntityFailedSearchTime = 0L;
-@@ -1140,13 +1137,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1146,13 +1143,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateExtractionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.extractInventoryEntityTracker != null) {
@@ -81,7 +81,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
                  this.collectItemEntityTracker = null;
                  this.collectItemEntityBox = null;
                  this.collectItemEntityTrackerWasEmpty = false;
-@@ -1282,7 +1279,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1288,7 +1285,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.insertInventoryEntityTracker == null) {
              this.initInsertInventoryTracker(world);
          }
@@ -90,7 +90,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
              this.insertInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1347,7 +1344,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1353,7 +1350,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.extractInventoryEntityTracker == null) {
              this.initExtractInventoryTracker(level);
          }
@@ -99,7 +99,7 @@ index e1cf1057e9dd6cc859621d791ec62bbb2bcff04b..0a622da1b4510922c60e36b587ec3851
              this.extractInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1467,7 +1464,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1473,7 +1470,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          long modCount = net.caffeinemc.mods.lithium.common.hopper.InventoryHelper.getLithiumStackList(hopperBlockEntity).getModCount();
  
          if ((hopperBlockEntity.collectItemEntityTrackerWasEmpty || hopperBlockEntity.myModCountAtLastItemCollect == modCount) &&

--- a/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
+++ b/leaf-server/minecraft-patches/features/0311-Replace-Lithium-tracker-list-with-array.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Replace Lithium tracker list with array
 
 
 diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f3eaa05c4 100644
+index c3b9880f125aee88f671f5e527043676b70bca4a..3162c02847a818afa2b9f873f4a75bc87db52e79 100644
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -870,21 +870,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -872,21 +872,18 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      //Mod count used to avoid transfer attempts that are known to fail (no change since last attempt)
      private long insertStackListModCount, extractStackListModCount;
  
@@ -33,7 +33,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
      @Nullable
      private AABB insertInventoryEntityBox;
      private long insertInventoryEntityFailedSearchTime;
-@@ -966,19 +963,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -968,19 +965,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
              ((net.caffeinemc.mods.lithium.common.block.entity.inventory_change_tracking.InventoryChangeTracker) this.insertBlockInventory).listenForContentChangesOnce(this.insertStackList, this);
          }
          if (listenToInsertEntities) {
@@ -56,7 +56,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
                  return;
              }
              net.caffeinemc.mods.lithium.common.tracking.entity.ChunkSectionEntityMovementTracker.listenToEntityMovementOnce(this, collectItemEntityTracker);
-@@ -1113,7 +1110,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1115,7 +1112,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateInsertionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.insertInventoryEntityTracker != null) {
@@ -65,7 +65,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
                  this.insertInventoryEntityTracker = null;
                  this.insertInventoryEntityBox = null;
                  this.insertInventoryEntityFailedSearchTime = 0L;
-@@ -1141,13 +1138,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1143,13 +1140,13 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
      private void invalidateExtractionData() {
          if (this.level instanceof net.minecraft.server.level.ServerLevel) {
              if (this.extractInventoryEntityTracker != null) {
@@ -81,7 +81,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
                  this.collectItemEntityTracker = null;
                  this.collectItemEntityBox = null;
                  this.collectItemEntityTrackerWasEmpty = false;
-@@ -1283,7 +1280,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1285,7 +1282,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.insertInventoryEntityTracker == null) {
              this.initInsertInventoryTracker(world);
          }
@@ -90,7 +90,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
              this.insertInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1348,7 +1345,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1350,7 +1347,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          if (this.extractInventoryEntityTracker == null) {
              this.initExtractInventoryTracker(level);
          }
@@ -99,7 +99,7 @@ index b309946226f214ac2013667e5b0fce2257229475..24b2af29a176494f5d224af9b4e86a2f
              this.extractInventoryEntityFailedSearchTime = this.tickedGameTime;
              return null;
          }
-@@ -1468,7 +1465,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -1470,7 +1467,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
          long modCount = net.caffeinemc.mods.lithium.common.hopper.InventoryHelper.getLithiumStackList(hopperBlockEntity).getModCount();
  
          if ((hopperBlockEntity.collectItemEntityTrackerWasEmpty || hopperBlockEntity.myModCountAtLastItemCollect == modCount) &&


### PR DESCRIPTION
hopperPull 在转移成功后会无条件把剩余数量回写源容器，补丁逻辑假设 removeItem() 返回的是独立拷贝（普通容器确实如此），但雕文书架的 removeItem 直接返回槽位里原来那个对象引用而不做拷贝，导致回写时改的其实是已经插入漏斗里的那个同一对象。最终漏斗和书架指向同一个 count=0 的幽灵 ItemStack，两边都变空，书凭空消失。

Fix #883