### PR TITLE
Support wildcards in world name lists

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/config/WorldList.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/WorldList.java
@@ -1,0 +1,72 @@
+package org.dreeam.leaf.config;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/// A world name list read from the config, matching either exact names or `*` wildcard patterns.
+///
+/// `*` matches any (possibly empty) sequence of characters, so `hub*` matches `hub01` and `hub02`,
+/// and `*hub*` matches every world whose name contains `hub`. Entries without `*` are matched
+/// exactly, as before. Matching is case sensitive, like world folder names.
+@NullMarked
+public final class WorldList {
+
+    private static final Pattern[] NO_PATTERNS = {};
+
+    public static final WorldList EMPTY = new WorldList(List.of());
+
+    private final Set<String> names = new HashSet<>();
+    private final Pattern[] patterns;
+
+    public WorldList(List<String> entries) {
+        List<Pattern> patterns = new ArrayList<>();
+        for (String entry : entries) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            String trimmed = entry.trim();
+            if (trimmed.indexOf('*') == -1) {
+                this.names.add(trimmed);
+            } else {
+                patterns.add(compile(trimmed));
+            }
+        }
+        this.patterns = patterns.toArray(NO_PATTERNS);
+    }
+
+    public boolean isEmpty() {
+        return this.names.isEmpty() && this.patterns.length == 0;
+    }
+
+    public boolean contains(String worldName) {
+        if (this.names.contains(worldName)) {
+            return true;
+        }
+        for (Pattern pattern : this.patterns) {
+            if (pattern.matcher(worldName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Pattern compile(String glob) {
+        String[] literals = glob.split("\\*", -1);
+        StringBuilder regex = new StringBuilder(glob.length() + 8);
+        for (int i = 0; i < literals.length; i++) {
+            if (i != 0) {
+                regex.append(".*");
+            }
+            if (!literals[i].isEmpty()) {
+                regex.append(Pattern.quote(literals[i]));
+            }
+        }
+        // DOTALL so '*' also covers line terminators, world names are not required to be single line
+        return Pattern.compile(regex.toString(), Pattern.DOTALL);
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/DisableWorldDataSaving.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/DisableWorldDataSaving.java
@@ -3,7 +3,7 @@ package org.dreeam.leaf.config.modules.misc;
 import net.minecraft.server.level.ServerLevel;
 import org.dreeam.leaf.config.ConfigModule;
 import org.dreeam.leaf.config.ConfigCategory;
-import org.dreeam.leaf.config.WorldList;
+import org.dreeam.leaf.util.list.WorldList;
 
 import java.util.ArrayList;
 

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/DisableWorldDataSaving.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/DisableWorldDataSaving.java
@@ -3,13 +3,13 @@ package org.dreeam.leaf.config.modules.misc;
 import net.minecraft.server.level.ServerLevel;
 import org.dreeam.leaf.config.ConfigModule;
 import org.dreeam.leaf.config.ConfigCategory;
+import org.dreeam.leaf.config.WorldList;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class DisableWorldDataSaving extends ConfigModule {
 
-    public static List<String> worlds = new ArrayList<>();
+    public static WorldList worlds = WorldList.EMPTY;
 
     public String basePath() {
         return ConfigCategory.MISC.basePath() + ".disable-world-data-saving";
@@ -17,13 +17,17 @@ public class DisableWorldDataSaving extends ConfigModule {
 
     @Override
     public void onLoaded() {
-        worlds = globalConfig.getList(basePath() + ".worlds", worlds,
+        worlds = new WorldList(globalConfig.getList(basePath() + ".worlds", new ArrayList<>(),
             globalConfig.pickStringRegionBased("""
                     Worlds listed here will skip world data persistence.
-                    Changes in chunks/entities remain in memory until unload/restart and are not written to disk.""",
+                    Changes in chunks/entities remain in memory until unload/restart and are not written to disk.
+                    '*' works as a wildcard, e.g. 'hub*' matches hub01 and hub02, '*hub*' matches every world
+                    whose name contains 'hub'. Entries without '*' are matched exactly.""",
                 """
                     此处列出的世界将跳过世界数据持久化。
-                    区块/实体更改仅保留在内存中直到卸载或重启，不会写入磁盘。"""));
+                    区块/实体更改仅保留在内存中直到卸载或重启，不会写入磁盘。
+                    '*' 可作为通配符使用, 例如 'hub*' 匹配 hub01 和 hub02, '*hub*' 匹配名称中包含 'hub' 的所有世界。
+                    不含 '*' 的条目按完整名称精确匹配。""")));
     }
 
     public static boolean shouldSkipSave(ServerLevel serverLevel) {

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/list/WorldList.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/list/WorldList.java
@@ -1,4 +1,4 @@
-package org.dreeam.leaf.config;
+package org.dreeam.leaf.util.list;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -29,11 +29,10 @@ public final class WorldList {
             if (entry == null || entry.isBlank()) {
                 continue;
             }
-            String trimmed = entry.trim();
-            if (trimmed.indexOf('*') == -1) {
-                this.names.add(trimmed);
+            if (entry.indexOf('*') == -1) {
+                this.names.add(entry);
             } else {
-                patterns.add(compile(trimmed));
+                patterns.add(compile(entry));
             }
         }
         this.patterns = patterns.toArray(NO_PATTERNS);


### PR DESCRIPTION
Closes #807.

World name lists in the config can now use `*` as a wildcard instead of spelling out every world:

```yaml
misc:
  disable-world-data-saving:
    worlds:
      - auth_lobby   # exact name, as before
      - hub*         # hub01, hub02, ...
      - '*hub*'      # every world whose name contains "hub"
```

`*` matches any (possibly empty) sequence of characters, and a pattern has to match the whole
name, so `hub*` does not match `myhub01`. Entries without `*` keep being matched exactly, so
existing configs behave exactly as before.

### Implementation

`org.dreeam.leaf.config.WorldList` holds the exact names in a `HashSet` and compiles the
wildcard entries into `Pattern`s once at config load, so matching does no per-call parsing.
`DisableWorldDataSaving.shouldSkipSave` keeps its `isEmpty()` short circuit, meaning servers
that do not use the option pay nothing. The only call sites are chunk/entity/POI saving and
`ServerLevel#save`, next to NBT serialization and disk IO, so a regex match there is noise.

Currently `disable-world-data-saving.worlds` is the only world list in the config; `WorldList`
is written so any future one can reuse it.

### Notes

The issue proposed a `--hub` prefix to mean "contains". I went with `*` instead: it expresses
contains (`*hub*`), prefix (`hub*`) and suffix (`*hub`) with the same syntax, it is the
convention users already know, and `*` is not a legal character in world folder names on
Windows, so it cannot collide with an existing exact entry. Happy to switch to another syntax
if you prefer.

Matching is case sensitive, like world folder names.

### Testing

Verified against the compiled class with assertions covering: regex metacharacters in world
names staying literal (`a+b`, `c(d)`, `e.f*`, `*g|h`), `Pattern.quote` with an embedded `\E`,
multiple and adjacent wildcards, anchoring (`hub` not matching `hub01`), unicode names,
case sensitivity, and blank/null entries being skipped.