### PR TITLE
Fix/async path max fall distance

### DIFF
--- a/leaf-server/minecraft-patches/features/0101-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0101-Petal-Async-Pathfinding.patch
@@ -13,6 +13,7 @@ Original project: https://github.com/Bloom-host/Petal
 Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Co-authored-by: Taiyou06 <kaandindar21@gmail.com>
 Co-authored-by: Altiami <yoshimo.kristin@gmail.com>
+Co-authored-by: MrlingXD <90316914+wling-art@users.noreply.github.com>
 
 This patch was ported downstream from the Petal fork.
 
@@ -1130,4 +1131,31 @@ index 64e1a34de133beccb90486f247e7e74d6535941f..5d2f56999657cc9b0d5892ddc7897d96
 +    public @Nullable PathTypeCache cache; // Kaiiju - petal - async path processing - private -> public-f
      private final BlockPos mobPosition;
      private final BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
+ 
+diff --git a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
+index 29da2af5d4a09f3ff21fa2d0653c05d45c475aa6..2dbea65ef0f9eac7e2cc9764426bd6fad442619b 100644
+--- a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
++++ b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
+@@ -34,11 +34,13 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+     private final Long2ObjectMap<PathType> pathTypesByPosCacheByMob = new Long2ObjectOpenHashMap<>();
+     private final Object2BooleanMap<AABB> collisionCache = new Object2BooleanOpenHashMap<>();
+     private final Node[] reusableNeighbors = new Node[Direction.Plane.HORIZONTAL.length()];
++    private int maxFallDistance; // Kaiiju - petal - async path processing - snapshot on main thread
+ 
+     @Override
+     public void prepare(final PathNavigationRegion level, final Mob entity) {
+         super.prepare(level, entity);
+         entity.onPathfindingStart();
++        this.maxFallDistance = entity.getMaxFallDistance(); // Kaiiju - petal - async path processing - snapshot on main thread
+     }
+ 
+     @Override
+@@ -351,7 +353,7 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+ 
+     private Node tryFindFirstGroundNodeBelow(final int x, final int y, final int z) {
+         for (int currentY = y - 1; currentY >= this.mob.level().getMinY(); currentY--) {
+-            if (y - currentY > this.mob.getMaxFallDistance()) {
++            if (y - currentY > this.maxFallDistance) { // Kaiiju - petal - async path processing - snapshot on main thread
+                 return this.getBlockedNode(x, currentY, z);
+             }
  

--- a/leaf-server/minecraft-patches/features/0221-Cache-block-state-tags.patch
+++ b/leaf-server/minecraft-patches/features/0221-Cache-block-state-tags.patch
@@ -129,10 +129,10 @@ index 5d2f56999657cc9b0d5892ddc7897d96610a0dbd..864681a98d963575acb0d88c710e68f2
  
      public BlockState getBlockState(final BlockPos pos) {
 diff --git a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
-index 29da2af5d4a09f3ff21fa2d0653c05d45c475aa6..4972797702c5a86f9322d60cf95726996912eec5 100644
+index 2dbea65ef0f9eac7e2cc9764426bd6fad442619b..6780690213a2b040fd0bafee90be3fd5fc525c1f 100644
 --- a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
 +++ b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
-@@ -513,6 +513,17 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+@@ -515,6 +515,17 @@ public class WalkNodeEvaluator extends NodeEvaluator {
          return blockPathType;
      }
  
@@ -150,7 +150,7 @@ index 29da2af5d4a09f3ff21fa2d0653c05d45c475aa6..4972797702c5a86f9322d60cf9572699
      protected static PathType getPathTypeFromState(final BlockGetter level, final BlockPos pos) {
          // Paper start - Do not load chunks during pathfinding
          BlockState blockState = level.getBlockStateIfLoaded(pos);
-@@ -520,6 +531,11 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+@@ -522,6 +533,11 @@ public class WalkNodeEvaluator extends NodeEvaluator {
              return PathType.BLOCKED;
          }
          // Paper end

--- a/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
+++ b/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
@@ -643,10 +643,10 @@ index 49d959160337f61a40cb94c31aec8dad0aee3839..a4fa389670f3f4ac6df5d2d95aa14884
              if (hasMalus(nodes.get(direction)) && hasMalus(nodes.get(secondDirection))) {
                  Node diagonalNode = this.findAcceptedNode(
 diff --git a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
-index 4972797702c5a86f9322d60cf95726996912eec5..f1b068e4ff3642b31ded349bfa0aad665e8d0446 100644
+index 6780690213a2b040fd0bafee90be3fd5fc525c1f..32eb719fe2a8e9c18c7db49344446c02ca067723 100644
 --- a/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
 +++ b/net/minecraft/world/level/pathfinder/WalkNodeEvaluator.java
-@@ -129,7 +129,7 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+@@ -131,7 +131,7 @@ public class WalkNodeEvaluator extends NodeEvaluator {
  
          double posHeight = this.getFloorLevel(new BlockPos(pos.x, pos.y, pos.z));
  
@@ -655,7 +655,7 @@ index 4972797702c5a86f9322d60cf95726996912eec5..f1b068e4ff3642b31ded349bfa0aad66
              Node node = this.findAcceptedNode(
                  pos.x + direction.getStepX(), pos.y, pos.z + direction.getStepZ(), jumpSize, posHeight, direction, blockPathTypeCurrent
              );
-@@ -139,7 +139,7 @@ public class WalkNodeEvaluator extends NodeEvaluator {
+@@ -141,7 +141,7 @@ public class WalkNodeEvaluator extends NodeEvaluator {
              }
          }
  


### PR DESCRIPTION
大概的问题是，EntityReference 本身是 Either<UUID, Mob>。

但是走异步路径的时候，如果顺着 mob.getMaxFallDistance() 读到 EntityReference，这时候手里可能只有 UUID，没有实际的 Mob。接下来再走 level.getEntityInAnyDimension(uuid)，里面的 AsyncCatcher.catchOp 就会直接因为异步访问而抛异常。

## 报错

<img width="883" height="488" alt="IMG_1643" src="https://github.com/user-attachments/assets/9c536bcc-5542-44fd-b984-8790ee7c261e" />

## 解决办法

在创建 async path 之前，就先把 maxFallDistance 算出来并传进去，异步路径里就不用再去拿 Entity 了。

顺便还有一点优化。之前是每往下走一步，就重新问一次、算一次 maxFallDistance。现在则是提前算好之后直接固定用这个值，不需要重复计算。

代价就是，这里的 maxFallDistance 变成了一个快照，后面如果它发生变化，async path 里不会实时跟着变。

不过我看了一下原版的逻辑，路径怎么走本来就是在请求发生的时计算出来的，后面也不会重新算。所以从这个角度来说，这种处理方式其实反而更接近 Vanilla 的行为。