### PR TITLE
Fix existing issues of secure seed

### DIFF
--- a/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
+++ b/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
@@ -9,11 +9,36 @@ Original project: https://github.com/plasmoapp/matter
 Co-authored-by: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
 Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
+diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
+index e5b7132b2b310d2e501c0a82ea6e7663f66bec65..7284b138fac14223abf68572425b5d843ae5308f 100644
+--- a/net/minecraft/server/MinecraftServer.java
++++ b/net/minecraft/server/MinecraftServer.java
+@@ -719,6 +719,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         );
+         final org.bukkit.generator.ChunkGenerator chunkGenerator = this.server.getGenerator(loading.data().bukkitName());
+         org.bukkit.generator.BiomeProvider biomeProvider = this.server.getBiomeProvider(loading.data().bukkitName());
++        // Leaf start - Matter - Secure Seed
++        final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext = su.plo.matter.TerrainCryptoContext.create(
++            worldDataAndGenSettings.genSettings().options(),
++            dimensionKey
++        );
++        // Leaf end - Matter - Secure Seed
+         final org.bukkit.generator.WorldInfo worldInfo = new org.bukkit.craftbukkit.generator.CraftWorldInfo(
+             loading.data().bukkitName(),
+             org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(loading.info().dimensionKey().identifier()),
+@@ -728,6 +734,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+             levelStem.type().value(),
+             levelStem.generator(),
+             this.registryAccess(),
++            terrainCryptoContext, // Leaf - Matter - Secure Seed
+             loading.data().uuid()
+         );
+         if (biomeProvider == null && chunkGenerator != null) {
 diff --git a/net/minecraft/server/dedicated/DedicatedServerProperties.java b/net/minecraft/server/dedicated/DedicatedServerProperties.java
-index 425d071c5cb51c596748093b16bb2ac8386e10dd..68c39bd35fefeaf98e351dd76498cb475899dfcb 100644
+index 425d071c5cb51c596748093b16bb2ac8386e10dd..082374cd06b10c537d97aaea225e025886d31d95 100644
 --- a/net/minecraft/server/dedicated/DedicatedServerProperties.java
 +++ b/net/minecraft/server/dedicated/DedicatedServerProperties.java
-@@ -140,7 +140,17 @@ public class DedicatedServerProperties extends Settings<DedicatedServerPropertie
+@@ -140,7 +140,40 @@ public class DedicatedServerProperties extends Settings<DedicatedServerPropertie
          String levelSeed = this.get("level-seed", "");
          boolean generateStructures = this.get("generate-structures", true);
          long seed = WorldOptions.parseSeed(levelSeed).orElse(WorldOptions.randomSeed());
@@ -23,8 +48,31 @@ index 425d071c5cb51c596748093b16bb2ac8386e10dd..68c39bd35fefeaf98e351dd76498cb47
 +            String featureSeedStr = this.get("feature-level-seed", "");
 +            long[] featureSeed = su.plo.matter.Globals.parseSeed(featureSeedStr)
 +                    .orElse(su.plo.matter.Globals.createRandomWorldSeed());
++            if (org.dreeam.leaf.config.modules.misc.SecureSeed.isSecureTerrainEnabled()) {
++                String terrainSeedStr = this.get("terrain-level-seed", "");
++                su.plo.matter.TerrainCrypto terrainCrypto;
++                if (terrainSeedStr.isEmpty()) {
++                    terrainCrypto = su.plo.matter.TerrainCrypto.random();
++                } else {
++                    try {
++                        terrainCrypto = su.plo.matter.TerrainCrypto.fromHex(terrainSeedStr);
++                    } catch (IllegalArgumentException ex) {
++                        if (!org.dreeam.leaf.util.LeafConstants.DISABLE_SECURE_SEED_INTEGRITY_CHECK) {
++                            throw ex;
++                        }
++                        LOGGER.error(
++                            "Invalid terrain-level-seed was discarded because -D{}=true. A random terrain master seed will be used instead.",
++                            org.dreeam.leaf.util.LeafConstants.DISABLE_SECURE_SEED_INTEGRITY_CHECK_FLAG,
++                            ex
++                        );
++                        terrainCrypto = su.plo.matter.TerrainCrypto.random();
++                    }
++                }
 +
-+            this.worldOptions = new WorldOptions(seed, featureSeed, generateStructures, false);
++                this.worldOptions = new WorldOptions(seed, featureSeed, terrainCrypto, generateStructures, false);
++            } else {
++                this.worldOptions = new WorldOptions(seed, featureSeed, generateStructures, false);
++            }
 +        } else {
 +            this.worldOptions = new WorldOptions(seed, generateStructures, false);
 +        }
@@ -32,6 +80,19 @@ index 425d071c5cb51c596748093b16bb2ac8386e10dd..68c39bd35fefeaf98e351dd76498cb47
          this.worldDimensionData = new DedicatedServerProperties.WorldDimensionData(
              this.get("generator-settings", s -> GsonHelper.parse(!s.isEmpty() ? s : "{}"), new JsonObject()),
              this.get("level-type", v -> v.toLowerCase(Locale.ROOT), WorldPresets.NORMAL.identifier().toString())
+diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
+index e8000d4ee264c4d0e81a1417a9cafe537a910f6f..a793ab479dad54babae478136d192fa6255fabf5 100644
+--- a/net/minecraft/server/level/ChunkMap.java
++++ b/net/minecraft/server/level/ChunkMap.java
+@@ -206,7 +206,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+         }
+         if (randomGenerator instanceof NoiseBasedChunkGenerator noiseGenerator) {
+             // CraftBukkit end
+-            this.randomState = RandomState.create(noiseGenerator.generatorSettings().value(), registryAccess.lookupOrThrow(Registries.NOISE), levelSeed);
++            this.randomState = RandomState.create(noiseGenerator.generatorSettings().value(), registryAccess.lookupOrThrow(Registries.NOISE), levelSeed, level.leaf$terrainCryptoContext); // Leaf - Matter - Secure Seed
+         } else {
+             this.randomState = RandomState.create(NoiseGeneratorSettings.dummy(), registryAccess.lookupOrThrow(Registries.NOISE), levelSeed);
+         }
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
 index 98f07bacb2a94b368c1969dc0cfb11b72f6cea1a..6755281b1dedf2078e1623918985de772bb78dfe 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
@@ -45,26 +106,28 @@ index 98f07bacb2a94b368c1969dc0cfb11b72f6cea1a..6755281b1dedf2078e1623918985de77
      }
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6638155dd34519592893bf992ad5050f30c39626..04b5f7e49e98d8c2bf2152876c529f0cd52725ad 100644
+index 6638155dd34519592893bf992ad5050f30c39626..e314c9975e0cd757155ad327d881a8e8da3b54ec 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -231,6 +231,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -231,6 +231,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private final WeatherData weatherData;
      public final net.minecraft.world.level.timers.TimerQueue<net.minecraft.server.MinecraftServer> scheduledEvents;
      public final WorldGenSettings worldGenSettings;
 +    public final su.plo.matter.Globals.@Nullable DimensionSeed matter$dimensionSeed; // Leaf - Matter - Secure Seed
++    public final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext leaf$terrainCryptoContext; // Leaf - Matter - Secure Seed
      private @Nullable ServerClockManager clockManager;
      public boolean hasPhysicsEvent = true; // Paper - BlockPhysicsEvent
      public boolean hasEntityMoveEvent; // Paper - Add EntityMoveEvent
-@@ -644,6 +645,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -644,6 +646,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.uuid = loadedWorldData.uuid();
          this.levelLoadListener = new net.minecraft.server.level.progress.LoggingLevelLoadListener(false, this);
          this.worldGenSettings = worldGenSettings;
 +        this.matter$dimensionSeed = org.dreeam.leaf.config.modules.misc.SecureSeed.enabled ? su.plo.matter.Globals.createDimensionSeed(dimension) : null; // Leaf - Matter - Secure Seed
++        this.leaf$terrainCryptoContext = su.plo.matter.TerrainCryptoContext.create(worldGenSettings.options(), dimension); // Leaf - Matter - Secure Seed
          this.scheduledEvents = savedDataStorage.computeIfAbsent(net.minecraft.world.level.timers.TimerQueue.TYPE);
          // CraftBukkit end
          this.tickTime = tickTime;
-@@ -692,6 +694,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -692,6 +696,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              generator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, generator, gen);
          }
          // CraftBukkit end
@@ -72,6 +135,19 @@ index 6638155dd34519592893bf992ad5050f30c39626..04b5f7e49e98d8c2bf2152876c529f0c
          boolean syncWrites = server.forceSynchronousWrites();
          DataFixer fixerUpper = server.getFixerUpper();
          // Paper - rewrite chunk system
+diff --git a/net/minecraft/server/level/WorldGenRegion.java b/net/minecraft/server/level/WorldGenRegion.java
+index 015539951e2a6af0e7b50c05512d1f6200ef2797..0626af0efa86ac0d464f261e0ac1b96ba7de965b 100644
+--- a/net/minecraft/server/level/WorldGenRegion.java
++++ b/net/minecraft/server/level/WorldGenRegion.java
+@@ -116,7 +116,7 @@ public class WorldGenRegion implements WorldGenLevel {
+         this.level = level;
+         this.seed = level.getSeed();
+         this.levelData = level.getLevelData();
+-        this.random = level.getChunkSource().randomState().getOrCreateRandomFactory(WORLDGEN_REGION_RANDOM).at(this.center.getPos().getWorldPosition());
++        this.random = level.getChunkSource().randomState().getOrCreateWorldgenRandomFactory(WORLDGEN_REGION_RANDOM).at(this.center.getPos().getWorldPosition()); // Leaf - Matter - Secure Seed
+         this.dimensionType = level.dimensionType();
+         this.biomeManager = new BiomeManager(this, BiomeManager.obfuscateSeed(this.seed));
+         ChunkPos centerPos = center.getPos();
 diff --git a/net/minecraft/world/entity/monster/cubemob/Slime.java b/net/minecraft/world/entity/monster/cubemob/Slime.java
 index 1faab89a0c6febdbbb15c8f1345fbd8e71f3af6e..5f10718fac8f0c267a2fba5f171dae3024f9f6bf 100644
 --- a/net/minecraft/world/entity/monster/cubemob/Slime.java
@@ -203,23 +279,225 @@ index 9208924f54d5024bc50ad4501fbff9eb2a289181..01d87d9c474a5f3e14713579e6a1d1e1
          if (chunk.getPersistedStatus().isBefore(this.targetStatus)) {
              ProfiledDuration profiledDuration = JvmProfiler.INSTANCE.onChunkGenerate(chunk.getPos(), context.level().dimension(), this.targetStatus.getName());
              return this.task.doWork(context, this, cache, chunk).thenApply(newCenterChunk -> this.completeChunkGeneration(newCenterChunk, profiledDuration));
+diff --git a/net/minecraft/world/level/levelgen/DensityFunctions.java b/net/minecraft/world/level/levelgen/DensityFunctions.java
+index ba8d4411b3868b60738b93e3d9e0f5df8a79639d..6e9072625314c1e8d04d44207ab943c0a642943f 100644
+--- a/net/minecraft/world/level/levelgen/DensityFunctions.java
++++ b/net/minecraft/world/level/levelgen/DensityFunctions.java
+@@ -511,7 +511,12 @@ public final class DensityFunctions {
+         // Paper end - Perf: Optimize end generation
+ 
+         public EndIslandDensityFunction(final long seed) {
+-            RandomSource islandRandom = new LegacyRandomSource(seed);
++            // Leaf start - Matter - Secure Seed
++            this(new LegacyRandomSource(seed));
++        }
++
++        public EndIslandDensityFunction(final RandomSource islandRandom) {
++        // Leaf end - Matter - Secure Seed
+             islandRandom.consumeCount(17292);
+             this.islandNoise = new SimplexNoise(islandRandom);
+         }
+diff --git a/net/minecraft/world/level/levelgen/RandomState.java b/net/minecraft/world/level/levelgen/RandomState.java
+index 7b74440fbbe79c018ad59d24b99da0c6d4a9d007..b5104e759126e93fd590b688fcb874e06c13afad 100644
+--- a/net/minecraft/world/level/levelgen/RandomState.java
++++ b/net/minecraft/world/level/levelgen/RandomState.java
+@@ -15,6 +15,7 @@ import net.minecraft.world.level.levelgen.synth.NormalNoise;
+ 
+ public final class RandomState {
+     private final PositionalRandomFactory random;
++    private final PositionalRandomFactory vanillaRandom; // Leaf - Matter - Secure Seed
+     private final HolderGetter<NormalNoise.NoiseParameters> noises;
+     private final NoiseRouter router;
+     private final Climate.Sampler sampler;
+@@ -23,23 +24,63 @@ public final class RandomState {
+     private final PositionalRandomFactory oreRandom;
+     private final Map<ResourceKey<NormalNoise.NoiseParameters>, NormalNoise> noiseIntances;
+     private final Map<Identifier, PositionalRandomFactory> positionalRandoms;
++    // Leaf start - Matter - Secure Seed
++    private final Map<Identifier, PositionalRandomFactory> vanillaPositionalRandoms;
++    private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext;
++    // Leaf end - Matter - Secure Seed
+ 
+     public static RandomState create(final HolderGetter.Provider holders, final ResourceKey<NoiseGeneratorSettings> noiseSettings, final long seed) {
+-        return create(holders.lookupOrThrow(Registries.NOISE_SETTINGS).getOrThrow(noiseSettings).value(), holders.lookupOrThrow(Registries.NOISE), seed);
++        // Leaf start - Matter - Secure Seed
++        return create(holders.lookupOrThrow(Registries.NOISE_SETTINGS).getOrThrow(noiseSettings).value(), holders.lookupOrThrow(Registries.NOISE), seed, null);
++    }
++
++    public static RandomState create(final HolderGetter.Provider holders, final ResourceKey<NoiseGeneratorSettings> noiseSettings, final long seed, final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext) {
++        return create(
++            holders.lookupOrThrow(Registries.NOISE_SETTINGS).getOrThrow(noiseSettings).value(),
++            holders.lookupOrThrow(Registries.NOISE),
++            seed,
++            terrainCryptoContext
++        );
++        // Leaf end - Matter - Secure Seed
+     }
+ 
+     public static RandomState create(final NoiseGeneratorSettings settings, final HolderGetter<NormalNoise.NoiseParameters> noises, final long seed) {
+-        return new RandomState(settings, noises, seed);
++        // Leaf start - Matter - Secure Seed
++        return new RandomState(settings, noises, seed, null);
+     }
+ 
+-    private RandomState(final NoiseGeneratorSettings settings, final HolderGetter<NormalNoise.NoiseParameters> noises, final long seed) {
+-        this.random = settings.getRandomSource().newInstance(seed).forkPositional();
++    public static RandomState create(final NoiseGeneratorSettings settings, final HolderGetter<NormalNoise.NoiseParameters> noises, final long seed, final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext) {
++        return new RandomState(settings, noises, seed, terrainCryptoContext);
++        // Leaf end - Matter - Secure Seed
++    }
++
++    // Leaf start - Matter - Secure Seed
++    private RandomState(final NoiseGeneratorSettings settings, final HolderGetter<NormalNoise.NoiseParameters> noises, final long seed, final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext) {
++        this.terrainCryptoContext = terrainCryptoContext;
++        this.vanillaRandom = settings.getRandomSource().newInstance(seed).forkPositional();
++        this.random = terrainCryptoContext == null
++            ? this.vanillaRandom
++            : terrainCryptoContext.initializationRandom("normal_noise").forkPositional();
++        // Leaf end - Matter - Secure Seed
+         this.noises = noises;
+-        this.aquiferRandom = this.random.fromHashOf(Identifier.withDefaultNamespace("aquifer")).forkPositional();
+-        this.oreRandom = this.random.fromHashOf(Identifier.withDefaultNamespace("ore")).forkPositional();
++        // Leaf start - Matter - Secure Seed
++        this.aquiferRandom = terrainCryptoContext == null
++            ? this.random.fromHashOf(Identifier.withDefaultNamespace("aquifer")).forkPositional()
++            : terrainCryptoContext.runtimeFactory("aquifer");
++        this.oreRandom = terrainCryptoContext == null
++            ? this.random.fromHashOf(Identifier.withDefaultNamespace("ore")).forkPositional()
++            : terrainCryptoContext.runtimeFactory("ore_vein");
++        // Leaf end - Matter - Secure Seed
+         this.noiseIntances = new ConcurrentHashMap<>();
+         this.positionalRandoms = new ConcurrentHashMap<>();
+-        this.surfaceSystem = new SurfaceSystem(this, settings.defaultBlock(), settings.seaLevel(), this.random);
++        // Leaf start - Matter - Secure Seed
++        this.vanillaPositionalRandoms = terrainCryptoContext == null ? this.positionalRandoms : new ConcurrentHashMap<>();
++        PositionalRandomFactory surfaceRandom = terrainCryptoContext == null ? this.random : terrainCryptoContext.runtimeFactory("surface");
++        RandomSource clayBandsRandom = terrainCryptoContext == null
++            ? surfaceRandom.fromHashOf(Identifier.withDefaultNamespace("clay_bands"))
++            : terrainCryptoContext.initializationRandom("surface/clay_bands");
++        this.surfaceSystem = new SurfaceSystem(this, settings.defaultBlock(), settings.seaLevel(), surfaceRandom, clayBandsRandom);
++        // Leaf end - Matter - Secure Seed
+         final boolean useLegacyInit = settings.useLegacyRandomSource();
+ 
+         class NoiseWiringHelper implements DensityFunction.Visitor {
+@@ -53,10 +94,20 @@ public final class RandomState {
+             public DensityFunction.NoiseHolder visitNoise(final DensityFunction.NoiseHolder noise) {
+                 Holder<NormalNoise.NoiseParameters> noiseData = noise.noiseData();
+                 if (noiseData.is(Noises.TEMPERATURE_NETHER)) {
+-                    NormalNoise newNoise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(0L), noiseData.value());
++                    // Leaf start - Matter - Secure Seed
++                    RandomSource random = terrainCryptoContext == null
++                        ? this.newLegacyInstance(0L)
++                        : terrainCryptoContext.initializationRandom("legacy_nether_temperature");
++                    NormalNoise newNoise = NormalNoise.createLegacyNetherBiome(random, noiseData.value());
++                    // Leaf end - Matter - Secure Seed
+                     return new DensityFunction.NoiseHolder(noiseData, newNoise);
+                 } else if (noiseData.is(Noises.VEGETATION_NETHER)) {
+-                    NormalNoise newNoise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(1L), noiseData.value());
++                    // Leaf start - Matter - Secure Seed
++                    RandomSource random = terrainCryptoContext == null
++                        ? this.newLegacyInstance(1L)
++                        : terrainCryptoContext.initializationRandom("legacy_nether_vegetation");
++                    NormalNoise newNoise = NormalNoise.createLegacyNetherBiome(random, noiseData.value());
++                    // Leaf end - Matter - Secure Seed
+                     return new DensityFunction.NoiseHolder(noiseData, newNoise);
+                 } else {
+                     NormalNoise instantiate = RandomState.this.getOrCreateNoise(noiseData.unwrapKey().orElseThrow());
+@@ -66,12 +117,22 @@ public final class RandomState {
+ 
+             private DensityFunction wrapNew(final DensityFunction function) {
+                 if (function instanceof BlendedNoise noise) {
+-                    RandomSource terrainRandom = useLegacyInit
+-                        ? this.newLegacyInstance(0L)
+-                        : RandomState.this.random.fromHashOf(Identifier.withDefaultNamespace("terrain"));
++                    // Leaf start - Matter - Secure Seed
++                    RandomSource terrainRandom = terrainCryptoContext == null
++                        ? (useLegacyInit
++                            ? this.newLegacyInstance(0L)
++                            : RandomState.this.random.fromHashOf(Identifier.withDefaultNamespace("terrain")))
++                        : terrainCryptoContext.initializationRandom("blended_noise");
+                     return noise.withNewRandom(terrainRandom);
++                    // Leaf end - Matter - Secure Seed
+                 } else {
+-                    return function instanceof DensityFunctions.EndIslandDensityFunction ? new DensityFunctions.EndIslandDensityFunction(seed) : function;
++                    // Leaf start - Matter - Secure Seed
++                    return function instanceof DensityFunctions.EndIslandDensityFunction
++                        ? (terrainCryptoContext == null
++                            ? new DensityFunctions.EndIslandDensityFunction(seed)
++                            : new DensityFunctions.EndIslandDensityFunction(terrainCryptoContext.initializationRandom("end_islands")))
++                        : function;
++                    // Leaf end - Matter - Secure Seed
+                 }
+             }
+ 
+@@ -113,9 +174,21 @@ public final class RandomState {
+         return this.noiseIntances.computeIfAbsent(noise, key -> Noises.instantiate(this.noises, this.random, noise));
+     }
+ 
++    // Leaf start - Matter - Secure Seed
+     public PositionalRandomFactory getOrCreateRandomFactory(final Identifier name) {
+-        return this.positionalRandoms.computeIfAbsent(name, key -> this.random.fromHashOf(name).forkPositional());
++        return this.positionalRandoms.computeIfAbsent(name, key -> this.terrainCryptoContext == null ? this.random.fromHashOf(key).forkPositional() : this.terrainCryptoContext.runtimeFactory("named/" + key));
++    }
++
++    public PositionalRandomFactory getOrCreateWorldgenRandomFactory(final Identifier name) {
++        return this.terrainCryptoContext == null
++            ? this.getOrCreateRandomFactory(name)
++            : this.vanillaPositionalRandoms.computeIfAbsent(name, key -> this.vanillaRandom.fromHashOf(key).forkPositional());
++    }
++
++    public boolean usesSecureTerrain() {
++        return this.terrainCryptoContext != null;
+     }
++    // Leaf end - Matter - Secure Seed
+ 
+     public NoiseRouter router() {
+         return this.router;
+diff --git a/net/minecraft/world/level/levelgen/SurfaceSystem.java b/net/minecraft/world/level/levelgen/SurfaceSystem.java
+index cb078856e2942907750ca2d5e7a16abb7e053b65..25dc6120f58b90819e95002788362ba95dcf0b95 100644
+--- a/net/minecraft/world/level/levelgen/SurfaceSystem.java
++++ b/net/minecraft/world/level/levelgen/SurfaceSystem.java
+@@ -48,11 +48,17 @@ public class SurfaceSystem {
+     private final NormalNoise surfaceSecondaryNoise;
+ 
+     public SurfaceSystem(final RandomState randomState, final BlockState defaultBlock, final int seaLevel, final PositionalRandomFactory noiseRandom) {
++        // Leaf start - Matter - Secure Seed
++        this(randomState, defaultBlock, seaLevel, noiseRandom, noiseRandom.fromHashOf(Identifier.withDefaultNamespace("clay_bands")));
++    }
++
++    public SurfaceSystem(final RandomState randomState, final BlockState defaultBlock, final int seaLevel, final PositionalRandomFactory noiseRandom, final RandomSource clayBandsRandom) {
++    // Leaf end - Matter - Secure Seed
+         this.defaultBlock = defaultBlock;
+         this.seaLevel = seaLevel;
+         this.noiseRandom = noiseRandom;
+         this.clayBandsOffsetNoise = randomState.getOrCreateNoise(Noises.CLAY_BANDS_OFFSET);
+-        this.clayBands = generateBands(noiseRandom.fromHashOf(Identifier.withDefaultNamespace("clay_bands")));
++        this.clayBands = generateBands(clayBandsRandom); // Leaf - Matter - Secure Seed
+         this.surfaceNoise = randomState.getOrCreateNoise(Noises.SURFACE);
+         this.surfaceSecondaryNoise = randomState.getOrCreateNoise(Noises.SURFACE_SECONDARY);
+         this.badlandsPillarNoise = randomState.getOrCreateNoise(Noises.BADLANDS_PILLAR);
 diff --git a/net/minecraft/world/level/levelgen/WorldOptions.java b/net/minecraft/world/level/levelgen/WorldOptions.java
-index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70593d5c04 100644
+index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..e43ce4992f5d3842c4e44b71644919c8efed1dcf 100644
 --- a/net/minecraft/world/level/levelgen/WorldOptions.java
 +++ b/net/minecraft/world/level/levelgen/WorldOptions.java
-@@ -10,8 +10,20 @@ import net.minecraft.util.RandomSource;
+@@ -10,8 +10,25 @@ import net.minecraft.util.RandomSource;
  import org.apache.commons.lang3.StringUtils;
  
  public class WorldOptions {
 +    // Leaf start - Matter - Secure Seed
 +    private static final com.google.gson.Gson GSON = new com.google.gson.Gson();
 +    private static final boolean isSecureSeedEnabled = org.dreeam.leaf.config.modules.misc.SecureSeed.enabled;
++    private static final boolean isSecureTerrainEnabled = org.dreeam.leaf.config.modules.misc.SecureSeed.isSecureTerrainEnabled();
++    private static final MapCodec<Optional<su.plo.matter.TerrainCrypto>> SECURE_TERRAIN_CODEC = isSecureTerrainEnabled
++        ? su.plo.matter.TerrainCrypto.CODEC.optionalFieldOf("secure_terrain").stable()
++        : MapCodec.unit(Optional.empty());
      public static final MapCodec<WorldOptions> CODEC = RecordCodecBuilder.mapCodec(
 -        i -> i.group(
 +        i -> isSecureSeedEnabled
 +            ? i.group(
 +                Codec.LONG.fieldOf("seed").stable().forGetter(WorldOptions::seed),
 +                Codec.STRING.fieldOf("feature_seed").orElse(GSON.toJson(su.plo.matter.Globals.createRandomWorldSeed())).stable().forGetter(WorldOptions::featureSeedSerialize),
++                SECURE_TERRAIN_CODEC.forGetter(options -> Optional.ofNullable(options.terrainCrypto)),
 +                Codec.BOOL.fieldOf("generate_structures").orElse(true).stable().forGetter(WorldOptions::generateStructures),
 +                Codec.BOOL.fieldOf("bonus_chest").orElse(false).stable().forGetter(WorldOptions::generateBonusChest),
 +                Codec.STRING.lenientOptionalFieldOf("legacy_custom_options").stable().forGetter(s -> s.legacyCustomOptions)
@@ -229,7 +507,7 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70
                  Codec.LONG.fieldOf("seed").stable().forGetter(WorldOptions::seed),
                  ExtraCodecs.optionalAlwaysPresentFieldOf(Codec.BOOL, "generate_structures", true).stable().forGetter(WorldOptions::generateStructures),
                  ExtraCodecs.optionalAlwaysPresentFieldOf(Codec.BOOL, "bonus_chest", false).stable().forGetter(WorldOptions::generateBonusChest),
-@@ -19,8 +31,14 @@ public class WorldOptions {
+@@ -19,8 +36,15 @@ public class WorldOptions {
              )
              .apply(i, i.stable(WorldOptions::new))
      );
@@ -242,10 +520,11 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70
 +    // Leaf end - Matter - Secure Seed
      private final long seed;
 +    private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed(); // Leaf - Matter - Secure Seed
++    private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto; // Leaf - HMAC secure terrain
      private final boolean generateStructures;
      private final boolean generateBonusChest;
      private final Optional<String> legacyCustomOptions;
-@@ -30,13 +48,32 @@ public class WorldOptions {
+@@ -30,24 +54,66 @@ public class WorldOptions {
      }
  
      public static WorldOptions defaultWithRandomSeed() {
@@ -263,23 +542,36 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70
  
 +    // Leaf start - Matter - Secure Seed
 +    public WorldOptions(final long seed, final long[] featureSeed, final boolean generateStructures, final boolean generateBonusChest) {
-+        this(seed, featureSeed, generateStructures, generateBonusChest, Optional.empty());
++        this(seed, featureSeed, isSecureTerrainEnabled ? su.plo.matter.TerrainCrypto.random() : null, generateStructures, generateBonusChest, Optional.empty());
 +    }
 +
-+    private WorldOptions(final long seed, final String featureSeedJson, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions) {
-+        this(seed, GSON.fromJson(featureSeedJson, long[].class), generateStructures, generateBonusChest, legacyCustomOptions);
++    public WorldOptions(final long seed, final long[] featureSeed, final su.plo.matter.TerrainCrypto terrainCrypto, final boolean generateStructures, final boolean generateBonusChest) {
++        this(seed, featureSeed, terrainCrypto, generateStructures, generateBonusChest, Optional.empty());
 +    }
 +
-+    private WorldOptions(final long seed, final long[] featureSeed, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions) {
-+        this(seed, generateStructures, generateBonusChest, legacyCustomOptions);
++    private WorldOptions(final long seed, final String featureSeedJson, final Optional<su.plo.matter.TerrainCrypto> terrainCrypto, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions) {
++        this(seed, GSON.fromJson(featureSeedJson, long[].class), isSecureTerrainEnabled ? terrainCrypto.orElseGet(su.plo.matter.TerrainCrypto::random) : null, generateStructures, generateBonusChest, legacyCustomOptions);
++    }
++
++    private WorldOptions(final long seed, final long[] featureSeed, final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions) {
++        this(seed, generateStructures, generateBonusChest, legacyCustomOptions, terrainCrypto);
 +        this.featureSeed = featureSeed;
 +    }
 +    // Leaf end - Matter - Secure Seed
 +
      private WorldOptions(final long seed, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions) {
++        this(seed, generateStructures, generateBonusChest, legacyCustomOptions, isSecureTerrainEnabled ? su.plo.matter.TerrainCrypto.random() : null);
++    }
++
++    private WorldOptions(final long seed, final boolean generateStructures, final boolean generateBonusChest, final Optional<String> legacyCustomOptions, final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto) {
          this.seed = seed;
          this.generateStructures = generateStructures;
-@@ -48,6 +85,16 @@ public class WorldOptions {
+         this.generateBonusChest = generateBonusChest;
+         this.legacyCustomOptions = legacyCustomOptions;
++        this.terrainCrypto = terrainCrypto; // Leaf - Matter - Secure Seed
+     }
+ 
+     public long seed() {
          return this.seed;
      }
  
@@ -291,12 +583,16 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70
 +    private String featureSeedSerialize() {
 +        return GSON.toJson(this.featureSeed);
 +    }
++
++    public su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto() {
++        return this.terrainCrypto;
++    }
 +    // Leaf end - Matter - Secure Seed
 +
      public boolean generateStructures() {
          return this.generateStructures;
      }
-@@ -60,17 +107,25 @@ public class WorldOptions {
+@@ -60,17 +126,25 @@ public class WorldOptions {
          return this.legacyCustomOptions.isPresent();
      }
  
@@ -304,21 +600,21 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..b23dd531d284647e614f07f134c41e70
      public WorldOptions withBonusChest(final boolean generateBonusChest) {
 -        return new WorldOptions(this.seed, this.generateStructures, generateBonusChest, this.legacyCustomOptions);
 +        return isSecureSeedEnabled
-+            ? new WorldOptions(this.seed, this.featureSeed, this.generateStructures, generateBonusChest, this.legacyCustomOptions)
++            ? new WorldOptions(this.seed, this.featureSeed, isSecureTerrainEnabled ? java.util.Objects.requireNonNull(this.terrainCrypto) : null, this.generateStructures, generateBonusChest, this.legacyCustomOptions)
 +            : new WorldOptions(this.seed, this.generateStructures, generateBonusChest, this.legacyCustomOptions);
      }
  
      public WorldOptions withStructures(final boolean generateStructures) {
 -        return new WorldOptions(this.seed, generateStructures, this.generateBonusChest, this.legacyCustomOptions);
 +        return isSecureSeedEnabled
-+            ? new WorldOptions(this.seed, this.featureSeed, generateStructures, this.generateBonusChest, this.legacyCustomOptions)
++            ? new WorldOptions(this.seed, this.featureSeed, isSecureTerrainEnabled ? java.util.Objects.requireNonNull(this.terrainCrypto) : null, generateStructures, this.generateBonusChest, this.legacyCustomOptions)
 +            : new WorldOptions(this.seed, generateStructures, this.generateBonusChest, this.legacyCustomOptions);
      }
  
      public WorldOptions withSeed(final OptionalLong seed) {
 -        return new WorldOptions(seed.orElse(randomSeed()), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions);
 +        return isSecureSeedEnabled
-+            ? new WorldOptions(seed.orElse(randomSeed()), su.plo.matter.Globals.createRandomWorldSeed(), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions)
++            ? new WorldOptions(seed.orElse(randomSeed()), su.plo.matter.Globals.createRandomWorldSeed(), isSecureTerrainEnabled ? java.util.Objects.requireNonNull(this.terrainCrypto) : null, this.generateStructures, this.generateBonusChest, this.legacyCustomOptions)
 +            : new WorldOptions(seed.orElse(randomSeed()), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions);
      }
 +    // Leaf end - Matter - Secure Seed

--- a/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
+++ b/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
@@ -45,10 +45,26 @@ index 98f07bacb2a94b368c1969dc0cfb11b72f6cea1a..6755281b1dedf2078e1623918985de77
      }
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index bc08326c6b8e0657357f57f9bc47ef3c55f7744f..306ab28189d3272efbdaaf09444accf52f570fee 100644
+index 6638155dd34519592893bf992ad5050f30c39626..04b5f7e49e98d8c2bf2152876c529f0cd52725ad 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -692,6 +692,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -231,6 +231,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+     private final WeatherData weatherData;
+     public final net.minecraft.world.level.timers.TimerQueue<net.minecraft.server.MinecraftServer> scheduledEvents;
+     public final WorldGenSettings worldGenSettings;
++    public final su.plo.matter.Globals.@Nullable DimensionSeed matter$dimensionSeed; // Leaf - Matter - Secure Seed
+     private @Nullable ServerClockManager clockManager;
+     public boolean hasPhysicsEvent = true; // Paper - BlockPhysicsEvent
+     public boolean hasEntityMoveEvent; // Paper - Add EntityMoveEvent
+@@ -644,6 +645,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         this.uuid = loadedWorldData.uuid();
+         this.levelLoadListener = new net.minecraft.server.level.progress.LoggingLevelLoadListener(false, this);
+         this.worldGenSettings = worldGenSettings;
++        this.matter$dimensionSeed = org.dreeam.leaf.config.modules.misc.SecureSeed.enabled ? su.plo.matter.Globals.createDimensionSeed(dimension) : null; // Leaf - Matter - Secure Seed
+         this.scheduledEvents = savedDataStorage.computeIfAbsent(net.minecraft.world.level.timers.TimerQueue.TYPE);
+         // CraftBukkit end
+         this.tickTime = tickTime;
+@@ -692,6 +694,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              generator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, generator, gen);
          }
          // CraftBukkit end
@@ -57,7 +73,7 @@ index bc08326c6b8e0657357f57f9bc47ef3c55f7744f..306ab28189d3272efbdaaf09444accf5
          DataFixer fixerUpper = server.getFixerUpper();
          // Paper - rewrite chunk system
 diff --git a/net/minecraft/world/entity/monster/cubemob/Slime.java b/net/minecraft/world/entity/monster/cubemob/Slime.java
-index 1faab89a0c6febdbbb15c8f1345fbd8e71f3af6e..e9ccb195426b7d5631920c13f45a5611c8490f48 100644
+index 1faab89a0c6febdbbb15c8f1345fbd8e71f3af6e..5f10718fac8f0c267a2fba5f171dae3024f9f6bf 100644
 --- a/net/minecraft/world/entity/monster/cubemob/Slime.java
 +++ b/net/minecraft/world/entity/monster/cubemob/Slime.java
 @@ -169,7 +169,11 @@ public class Slime extends AbstractCubeMob implements Enemy {
@@ -67,14 +83,14 @@ index 1faab89a0c6febdbbb15c8f1345fbd8e71f3af6e..e9ccb195426b7d5631920c13f45a5611
 -            boolean slimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z(), worldGenLevel.getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
 +            // Leaf start - Matter - Secure Seed
 +            boolean slimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled
-+                ? level.getChunk(chunkPos.x(), chunkPos.z()).isSlimeChunk()
++                ? level.getChunk(chunkPos.x(), chunkPos.z()).isSlimeChunk(level.getMinecraftWorld())
 +                : WorldgenRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z(), worldGenLevel.getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0); // Paper
 +            // Leaf end - Matter - Secure Seed
              // Paper start - Replace rules for Height in Slime Chunks
              final double maxHeightSlimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.slimeChunk.maximum;
              if (random.nextInt(10) == 0 && slimeChunk && pos.getY() < maxHeightSlimeChunk) {
 diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
-index 28f703204afd834cd50335346ef065670d6b37ad..f6cecf0ec1ebf9dd7028877dcadf191d1a2d954c 100644
+index 28f703204afd834cd50335346ef065670d6b37ad..b21a7b634f3b00c17750c57ec5b21c43570fdb75 100644
 --- a/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/net/minecraft/world/level/chunk/ChunkAccess.java
 @@ -83,6 +83,10 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
@@ -88,15 +104,23 @@ index 28f703204afd834cd50335346ef065670d6b37ad..f6cecf0ec1ebf9dd7028877dcadf191d
  
      // Paper start - rewrite chunk system
      private volatile ca.spottedleaf.moonrise.patches.starlight.light.SWMRNibbleArray[] blockNibbles;
-@@ -186,6 +190,17 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
+@@ -186,6 +190,25 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
          return GameEventListenerRegistry.NOOP;
      }
  
 +    // Leaf start - Matter - Secure Seed
 +    public boolean isSlimeChunk() {
++        if (!(this.levelHeightAccessor instanceof net.minecraft.server.level.ServerLevel level)) {
++            throw new IllegalStateException("Cannot compute slime chunk without a ServerLevel");
++        }
++
++        return this.isSlimeChunk(level);
++    }
++
++    public boolean isSlimeChunk(net.minecraft.server.level.ServerLevel level) {
 +        if (!hasComputedSlimeChunk) {
++            slimeChunk = su.plo.matter.WorldgenCryptoRandom.seedSlimeChunk(level, chunkPos.x(), chunkPos.z()).nextInt(10) == 0;
 +            hasComputedSlimeChunk = true;
-+            slimeChunk = su.plo.matter.WorldgenCryptoRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z()).nextInt(10) == 0;
 +        }
 +
 +        return slimeChunk;
@@ -357,10 +381,10 @@ index 1310b2ca994b8f6d3d92bdc676fe44de3619cc09..bbb55a6d32b972546d391842d9d60223
          int spreadX = this.spreadType.evaluate(random, limit);
          int spreadZ = this.spreadType.evaluate(random, limit);
 diff --git a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
-index 646df0237a5a2863f75e6c5f9dfe9ddf512c540f..034613cc0f00a66a1c5fe510bb0c67c37dfa06dd 100644
+index 646df0237a5a2863f75e6c5f9dfe9ddf512c540f..d2958b0a0917e79e5509dfac81e39c5a9a4f16f4 100644
 --- a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
 +++ b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
-@@ -119,8 +119,15 @@ public abstract class StructurePlacement {
+@@ -119,34 +119,63 @@ public abstract class StructurePlacement {
      public abstract StructurePlacementType<?> type();
  
      private static boolean probabilityReducer(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs; ignore here
@@ -378,6 +402,64 @@ index 646df0237a5a2863f75e6c5f9dfe9ddf512c540f..034613cc0f00a66a1c5fe510bb0c67c3
          return random.nextFloat() < probability;
      }
  
+     private static boolean legacyProbabilityReducerWithDouble(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs
+-        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
+-        if (saltOverride == null) { // Paper - Add missing structure set seed configs
+-        random.setLargeFeatureSeed(seed, sourceX, sourceZ);
+-            // Paper start - Add missing structure set seed configs
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom random;
++        if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
++            random = new su.plo.matter.WorldgenCryptoRandom(sourceX, sourceZ, su.plo.matter.Globals.Salt.MINESHAFT_FEATURE, saltOverride != null ? saltOverride : 0);
+         } else {
+-            random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, saltOverride);
++            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            if (saltOverride == null) { // Paper - Add missing structure set seed configs
++                random.setLargeFeatureSeed(seed, sourceX, sourceZ);
++            // Paper start - Add missing structure set seed configs
++            } else {
++                random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, saltOverride);
++            }
++            // Paper end - Add missing structure set seed configs
+         }
+-        // Paper end - Add missing structure set seed configs
++        // Leaf end - Matter - Secure Seed
+         return random.nextDouble() < probability;
+     }
+ 
+     private static boolean legacyArbitrarySaltProbabilityReducer(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs
+-        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
+-        random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, saltOverride != null ? saltOverride : HIGHLY_ARBITRARY_RANDOM_SALT); // Paper - Add missing structure set seed configs
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom random;
++        int effectiveSalt = saltOverride != null ? saltOverride : HIGHLY_ARBITRARY_RANDOM_SALT; // Paper - Add missing structure set seed configs
++        if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
++            random = new su.plo.matter.WorldgenCryptoRandom(sourceX, sourceZ, su.plo.matter.Globals.Salt.BURIED_TREASURE_FEATURE, effectiveSalt);
++        } else {
++            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, effectiveSalt);
++        }
++        // Leaf end - Matter - Secure Seed
+         return random.nextFloat() < probability;
+     }
+ 
+     private static boolean legacyPillagerOutpostReducer(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs; ignore here
+         int cx = sourceX >> 4;
+         int cz = sourceZ >> 4;
+-        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
+-        random.setSeed(cx ^ cz << 4 ^ seed);
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom random;
++        if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
++            random = new su.plo.matter.WorldgenCryptoRandom(cx, cz, su.plo.matter.Globals.Salt.PILLAGER_OUTPOST_FEATURE, 0);
++        } else {
++            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            random.setSeed(cx ^ cz << 4 ^ seed);
++        }
++        // Leaf end - Matter - Secure Seed
+         random.nextInt();
+         return random.nextInt((int)(1.0F / probability)) == 0;
+     }
 diff --git a/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java b/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java
 index b92da7acae0789d955a9f71072b95ed030b879e2..0fb398c6dd1596a25277dd506b1edadde8e71d82 100644
 --- a/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java

--- a/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
+++ b/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
@@ -477,7 +477,7 @@ index cb078856e2942907750ca2d5e7a16abb7e053b65..25dc6120f58b90819e95002788362ba9
          this.surfaceSecondaryNoise = randomState.getOrCreateNoise(Noises.SURFACE_SECONDARY);
          this.badlandsPillarNoise = randomState.getOrCreateNoise(Noises.BADLANDS_PILLAR);
 diff --git a/net/minecraft/world/level/levelgen/WorldOptions.java b/net/minecraft/world/level/levelgen/WorldOptions.java
-index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..e43ce4992f5d3842c4e44b71644919c8efed1dcf 100644
+index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..5c061cb8382995d3e768a60617f01f82d2bdbf69 100644
 --- a/net/minecraft/world/level/levelgen/WorldOptions.java
 +++ b/net/minecraft/world/level/levelgen/WorldOptions.java
 @@ -10,8 +10,25 @@ import net.minecraft.util.RandomSource;
@@ -507,7 +507,7 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..e43ce4992f5d3842c4e44b71644919c8
                  Codec.LONG.fieldOf("seed").stable().forGetter(WorldOptions::seed),
                  ExtraCodecs.optionalAlwaysPresentFieldOf(Codec.BOOL, "generate_structures", true).stable().forGetter(WorldOptions::generateStructures),
                  ExtraCodecs.optionalAlwaysPresentFieldOf(Codec.BOOL, "bonus_chest", false).stable().forGetter(WorldOptions::generateBonusChest),
-@@ -19,8 +36,15 @@ public class WorldOptions {
+@@ -19,7 +36,14 @@ public class WorldOptions {
              )
              .apply(i, i.stable(WorldOptions::new))
      );
@@ -517,13 +517,12 @@ index 4ad94af024d81b7dfe910dcee2a6ec7a9b200d56..e43ce4992f5d3842c4e44b71644919c8
 +    public static final WorldOptions DEMO_OPTIONS = isSecureSeedEnabled
 +        ? new WorldOptions("North Carolina".hashCode(), su.plo.matter.Globals.createRandomWorldSeed(), true, true)
 +        : new WorldOptions("North Carolina".hashCode(), true, true);
++    private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed();
++    private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto;
 +    // Leaf end - Matter - Secure Seed
      private final long seed;
-+    private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed(); // Leaf - Matter - Secure Seed
-+    private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto; // Leaf - HMAC secure terrain
      private final boolean generateStructures;
      private final boolean generateBonusChest;
-     private final Optional<String> legacyCustomOptions;
 @@ -30,24 +54,66 @@ public class WorldOptions {
      }
  

--- a/leaf-server/minecraft-patches/features/0120-Matter-Secure-Seed-command.patch
+++ b/leaf-server/minecraft-patches/features/0120-Matter-Secure-Seed-command.patch
@@ -7,10 +7,10 @@ Original license: GPL-3.0-only
 Original project: https://github.com/plasmoapp/matter
 
 diff --git a/net/minecraft/server/commands/SeedCommand.java b/net/minecraft/server/commands/SeedCommand.java
-index 86ee3b3ae028597576b9549bc4954dfcbaa6732c..08d1040fde19f999a96773c368f7328b0d9f1e92 100644
+index 86ee3b3ae028597576b9549bc4954dfcbaa6732c..bcf0150b53549828ccb87e84c6be74718ccb6631 100644
 --- a/net/minecraft/server/commands/SeedCommand.java
 +++ b/net/minecraft/server/commands/SeedCommand.java
-@@ -13,6 +13,16 @@ public class SeedCommand {
+@@ -13,6 +13,24 @@ public class SeedCommand {
                  long seed = c.getSource().getLevel().getSeed();
                  Component seedText = ComponentUtils.copyOnClickText(String.valueOf(seed));
                  c.getSource().sendSuccess(() -> Component.translatable("commands.seed.success", seedText), false);
@@ -22,6 +22,14 @@ index 86ee3b3ae028597576b9549bc4954dfcbaa6732c..08d1040fde19f999a96773c368f7328b
 +                    Component featureSeedComponent = ComponentUtils.copyOnClickText(seedStr);
 +
 +                    c.getSource().sendSuccess(() -> Component.literal("Feature seed: ").append(featureSeedComponent), false);
++
++                    if (org.dreeam.leaf.config.modules.misc.SecureSeed.isSecureTerrainEnabled()) {
++                        su.plo.matter.TerrainCrypto terrainCrypto = c.getSource().getLevel().worldGenSettings.options().terrainCrypto();
++                        if (terrainCrypto != null && c.getSource().getLevel().getChunkSource().randomState().usesSecureTerrain()) {
++                            Component terrainSeedComponent = ComponentUtils.copyOnClickText(terrainCrypto.masterSeedHex());
++                            c.getSource().sendSuccess(() -> Component.literal("Terrain master seed: ").append(terrainSeedComponent), false);
++                        }
++                    }
 +                }
 +                // Leaf end - Matter - Secure Seed command
                  return (int)seed;

--- a/leaf-server/minecraft-patches/features/0120-Matter-Secure-Seed-command.patch
+++ b/leaf-server/minecraft-patches/features/0120-Matter-Secure-Seed-command.patch
@@ -7,20 +7,21 @@ Original license: GPL-3.0-only
 Original project: https://github.com/plasmoapp/matter
 
 diff --git a/net/minecraft/server/commands/SeedCommand.java b/net/minecraft/server/commands/SeedCommand.java
-index 86ee3b3ae028597576b9549bc4954dfcbaa6732c..f99c0c95aa4519ac0ce913032788aa168f44feef 100644
+index 86ee3b3ae028597576b9549bc4954dfcbaa6732c..08d1040fde19f999a96773c368f7328b0d9f1e92 100644
 --- a/net/minecraft/server/commands/SeedCommand.java
 +++ b/net/minecraft/server/commands/SeedCommand.java
-@@ -13,6 +13,15 @@ public class SeedCommand {
+@@ -13,6 +13,16 @@ public class SeedCommand {
                  long seed = c.getSource().getLevel().getSeed();
                  Component seedText = ComponentUtils.copyOnClickText(String.valueOf(seed));
                  c.getSource().sendSuccess(() -> Component.translatable("commands.seed.success", seedText), false);
 +                // Leaf start - Matter - Secure Seed command
 +                if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
-+                    su.plo.matter.Globals.setupGlobals(c.getSource().getLevel());
-+                    String seedStr = su.plo.matter.Globals.seedToString(su.plo.matter.Globals.worldSeed);
++                    String seedStr = su.plo.matter.Globals.seedToString(
++                        c.getSource().getLevel().worldGenSettings.options().featureSeed()
++                    );
 +                    Component featureSeedComponent = ComponentUtils.copyOnClickText(seedStr);
 +
-+                    c.getSource().sendSuccess(() -> Component.translatable(("Feature seed: %s"), featureSeedComponent), false);
++                    c.getSource().sendSuccess(() -> Component.literal("Feature seed: ").append(featureSeedComponent), false);
 +                }
 +                // Leaf end - Matter - Secure Seed command
                  return (int)seed;

--- a/leaf-server/minecraft-patches/features/0121-Faster-random-generator.patch
+++ b/leaf-server/minecraft-patches/features/0121-Faster-random-generator.patch
@@ -27,10 +27,10 @@ index 6755281b1dedf2078e1623918985de772bb78dfe..aa30556730b3c924f72ccd8702a88c38
          final ServerLevel world = this.level;
          final int randomTickSpeed = world.getGameRules().get(GameRules.RANDOM_TICK_SPEED);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 04b5f7e49e98d8c2bf2152876c529f0cd52725ad..bb899a34ce02bd3d418a3637834215bbecf56789 100644
+index e314c9975e0cd757155ad327d881a8e8da3b54ec..c7519b83a7b4ec1c658c8b8471a8a6f29789c36a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1000,7 +1000,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1002,7 +1002,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private void optimiseRandomTick(final LevelChunk chunk, final int tickSpeed) {
          final LevelChunkSection[] sections = chunk.getSections();
          final int minSection = ca.spottedleaf.moonrise.common.util.WorldUtil.getMinSection((ServerLevel)(Object)this);
@@ -39,7 +39,7 @@ index 04b5f7e49e98d8c2bf2152876c529f0cd52725ad..bb899a34ce02bd3d418a3637834215bb
          final boolean doubleTickFluids = !ca.spottedleaf.moonrise.common.PlatformHooks.get().configFixMC224294();
  
          final ChunkPos cpos = chunk.getPos();
-@@ -1047,7 +1047,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1049,7 +1049,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper end - optimise random ticking
  
      public void tickChunk(final LevelChunk chunk, final int tickSpeed) {
@@ -187,18 +187,18 @@ index 8ef42a332478a3d2cfb38254457ef86f62ab29f9..1a81fac30e86680653a60ec0b60bacf0
          if (!org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
          // Paper start - Add missing structure set seed configs
 diff --git a/net/minecraft/world/level/levelgen/DensityFunctions.java b/net/minecraft/world/level/levelgen/DensityFunctions.java
-index ba8d4411b3868b60738b93e3d9e0f5df8a79639d..053e8b52af29403db190283fc9ce2298a549417d 100644
+index 6e9072625314c1e8d04d44207ab943c0a642943f..6ffa5b98a37281e34e168a79ef7802b5f68bdd0c 100644
 --- a/net/minecraft/world/level/levelgen/DensityFunctions.java
 +++ b/net/minecraft/world/level/levelgen/DensityFunctions.java
-@@ -511,7 +511,7 @@ public final class DensityFunctions {
-         // Paper end - Perf: Optimize end generation
+@@ -512,7 +512,7 @@ public final class DensityFunctions {
  
          public EndIslandDensityFunction(final long seed) {
--            RandomSource islandRandom = new LegacyRandomSource(seed);
-+            RandomSource islandRandom = org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(seed) : new LegacyRandomSource(seed); // Leaf - Faster random generator
-             islandRandom.consumeCount(17292);
-             this.islandNoise = new SimplexNoise(islandRandom);
+             // Leaf start - Matter - Secure Seed
+-            this(new LegacyRandomSource(seed));
++            this(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(seed) : new LegacyRandomSource(seed)); // Leaf - Faster random generator
          }
+ 
+         public EndIslandDensityFunction(final RandomSource islandRandom) {
 diff --git a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
 index 9b4a52b73912d5a169565198d2b2a0263d74aa07..799c51701c8ebf0d95f76d9a0eca8b03e3d60812 100644
 --- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java

--- a/leaf-server/minecraft-patches/features/0121-Faster-random-generator.patch
+++ b/leaf-server/minecraft-patches/features/0121-Faster-random-generator.patch
@@ -27,10 +27,10 @@ index 6755281b1dedf2078e1623918985de772bb78dfe..aa30556730b3c924f72ccd8702a88c38
          final ServerLevel world = this.level;
          final int randomTickSpeed = world.getGameRules().get(GameRules.RANDOM_TICK_SPEED);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 306ab28189d3272efbdaaf09444accf52f570fee..0817fd8c0006272f1ed0bce560f1200324ff42ec 100644
+index 04b5f7e49e98d8c2bf2152876c529f0cd52725ad..bb899a34ce02bd3d418a3637834215bbecf56789 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -998,7 +998,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1000,7 +1000,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private void optimiseRandomTick(final LevelChunk chunk, final int tickSpeed) {
          final LevelChunkSection[] sections = chunk.getSections();
          final int minSection = ca.spottedleaf.moonrise.common.util.WorldUtil.getMinSection((ServerLevel)(Object)this);
@@ -39,7 +39,7 @@ index 306ab28189d3272efbdaaf09444accf52f570fee..0817fd8c0006272f1ed0bce560f12003
          final boolean doubleTickFluids = !ca.spottedleaf.moonrise.common.PlatformHooks.get().configFixMC224294();
  
          final ChunkPos cpos = chunk.getPos();
-@@ -1045,7 +1045,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1047,7 +1047,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper end - optimise random ticking
  
      public void tickChunk(final LevelChunk chunk, final int tickSpeed) {
@@ -97,7 +97,7 @@ index 664c1b3008b62c533b8e3302baa994ed0c135c42..bce2fc4fa3fc56edb2a29e5ba695ac8f
      static RandomSource createThreadLocalInstance(final long seed) {
          return new SingleThreadedRandomSource(seed);
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 7035d1ede6383c2016685cd2ca2f86e269f75c73..50c424b1d498d052bd27f37e855d0db3f780ee0b 100644
+index c2b845232253f3930ef90e8970b745c3dfea9bbf..4845fc18afed8229a2a4f00de1269145ceacdfe0 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -173,7 +173,7 @@ public abstract class Entity
@@ -300,7 +300,7 @@ index bbb55a6d32b972546d391842d9d6022316952eb9..0c26513f35812ac9bf0e569abf41a50c
          }
          // Leaf end - Matter - Secure Seed
 diff --git a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
-index 034613cc0f00a66a1c5fe510bb0c67c37dfa06dd..9e05aa4faf9ad5905a69584033474de8f424f8db 100644
+index d2958b0a0917e79e5509dfac81e39c5a9a4f16f4..57d4f7e5819308c67dc1b78ac17137dc6c94947d 100644
 --- a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
 +++ b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
 @@ -124,7 +124,7 @@ public abstract class StructurePlacement {
@@ -312,33 +312,33 @@ index 034613cc0f00a66a1c5fe510bb0c67c37dfa06dd..9e05aa4faf9ad5905a69584033474de8
              random.setLargeFeatureWithSalt(seed, salt, sourceX, sourceZ);
          }
          // Leaf end - Matter - Secure Seed
-@@ -132,7 +132,7 @@ public abstract class StructurePlacement {
-     }
- 
-     private static boolean legacyProbabilityReducerWithDouble(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs
--        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
-+        WorldgenRandom random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
-         if (saltOverride == null) { // Paper - Add missing structure set seed configs
-         random.setLargeFeatureSeed(seed, sourceX, sourceZ);
+@@ -137,7 +137,7 @@ public abstract class StructurePlacement {
+         if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
+             random = new su.plo.matter.WorldgenCryptoRandom(sourceX, sourceZ, su.plo.matter.Globals.Salt.MINESHAFT_FEATURE, saltOverride != null ? saltOverride : 0);
+         } else {
+-            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
+             if (saltOverride == null) { // Paper - Add missing structure set seed configs
+                 random.setLargeFeatureSeed(seed, sourceX, sourceZ);
              // Paper start - Add missing structure set seed configs
-@@ -144,7 +144,7 @@ public abstract class StructurePlacement {
-     }
- 
-     private static boolean legacyArbitrarySaltProbabilityReducer(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs
--        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
-+        WorldgenRandom random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
-         random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, saltOverride != null ? saltOverride : HIGHLY_ARBITRARY_RANDOM_SALT); // Paper - Add missing structure set seed configs
-         return random.nextFloat() < probability;
-     }
-@@ -152,7 +152,7 @@ public abstract class StructurePlacement {
-     private static boolean legacyPillagerOutpostReducer(final long seed, final int salt, final int sourceX, final int sourceZ, final float probability, final @org.jspecify.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs; ignore here
-         int cx = sourceX >> 4;
-         int cz = sourceZ >> 4;
--        WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
-+        WorldgenRandom random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
-         random.setSeed(cx ^ cz << 4 ^ seed);
-         random.nextInt();
-         return random.nextInt((int)(1.0F / probability)) == 0;
+@@ -157,7 +157,7 @@ public abstract class StructurePlacement {
+         if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
+             random = new su.plo.matter.WorldgenCryptoRandom(sourceX, sourceZ, su.plo.matter.Globals.Salt.BURIED_TREASURE_FEATURE, effectiveSalt);
+         } else {
+-            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
+             random.setLargeFeatureWithSalt(seed, sourceX, sourceZ, effectiveSalt);
+         }
+         // Leaf end - Matter - Secure Seed
+@@ -172,7 +172,7 @@ public abstract class StructurePlacement {
+         if (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) {
+             random = new su.plo.matter.WorldgenCryptoRandom(cx, cz, su.plo.matter.Globals.Salt.PILLAGER_OUTPOST_FEATURE, 0);
+         } else {
+-            random = new WorldgenRandom(new LegacyRandomSource(0L));
++            random = new WorldgenRandom(org.dreeam.leaf.config.modules.opt.FastRNG.worldgenEnabled() ? new org.dreeam.leaf.util.math.random.FasterRandomSource(0L) : new LegacyRandomSource(0L)); // Leaf - Faster random generator
+             random.setSeed(cx ^ cz << 4 ^ seed);
+         }
+         // Leaf end - Matter - Secure Seed
 diff --git a/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentStructure.java b/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentStructure.java
 index a856c0aa3c60d2de3d36ed0a9b372f872d62dfbb..c53010ac285f1737d360ae9a8c05c6134b156e99 100644
 --- a/net/minecraft/world/level/levelgen/structure/structures/OceanMonumentStructure.java

--- a/leaf-server/minecraft-patches/features/0141-Remove-stream-in-CraftWorld-spawnParticle.patch
+++ b/leaf-server/minecraft-patches/features/0141-Remove-stream-in-CraftWorld-spawnParticle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stream in CraftWorld#spawnParticle
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 72b03879dee9613423648dd2763a76a28f375704..6cc37813c571cd5a4a7bb6e97de4956ed7c0e121 100644
+index bb899a34ce02bd3d418a3637834215bbecf56789..00dc14586fd48416da67c22ce7575383876e4b1e 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2256,7 +2256,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2258,7 +2258,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (int i = 0; i < receivers.size(); i++) { // Paper - particle API
              ServerPlayer player = receivers.get(i); // Paper - particle API
@@ -17,7 +17,7 @@ index 72b03879dee9613423648dd2763a76a28f375704..6cc37813c571cd5a4a7bb6e97de4956e
              if (this.sendParticles(player, overrideLimiter, x, y, z, packet)) {
                  result++;
              }
-@@ -2265,6 +2265,44 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2267,6 +2267,44 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return result;
      }
  

--- a/leaf-server/minecraft-patches/features/0141-Remove-stream-in-CraftWorld-spawnParticle.patch
+++ b/leaf-server/minecraft-patches/features/0141-Remove-stream-in-CraftWorld-spawnParticle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stream in CraftWorld#spawnParticle
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index bb899a34ce02bd3d418a3637834215bbecf56789..00dc14586fd48416da67c22ce7575383876e4b1e 100644
+index c7519b83a7b4ec1c658c8b8471a8a6f29789c36a..8c7398aaf0d1964b94d69da8b3c8594f2d07a46f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2258,7 +2258,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2260,7 +2260,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (int i = 0; i < receivers.size(); i++) { // Paper - particle API
              ServerPlayer player = receivers.get(i); // Paper - particle API
@@ -17,7 +17,7 @@ index bb899a34ce02bd3d418a3637834215bbecf56789..00dc14586fd48416da67c22ce7575383
              if (this.sendParticles(player, overrideLimiter, x, y, z, packet)) {
                  result++;
              }
-@@ -2267,6 +2267,44 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2269,6 +2269,44 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return result;
      }
  

--- a/leaf-server/minecraft-patches/features/0166-TT20-Lag-compensation.patch
+++ b/leaf-server/minecraft-patches/features/0166-TT20-Lag-compensation.patch
@@ -9,10 +9,10 @@ Original project: https://github.com/snackbag/TT20
 Co-authored-by: MrlingXD <90316914+wling-art@users.noreply.github.com>
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index e5b7132b2b310d2e501c0a82ea6e7663f66bec65..53dfd4a95746d57a214da982a76cd0e847d27d60 100644
+index 7284b138fac14223abf68572425b5d843ae5308f..a2023539e70402a25d7d5452f63c6d734e9d374a 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1698,6 +1698,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1705,6 +1705,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          this.server.spark.tickStart(); // Paper - spark
          new com.destroystokyo.paper.event.server.ServerTickStartEvent(this.tickCount+1).callEvent(); // Paper - Server Tick Events

--- a/leaf-server/minecraft-patches/features/0173-Cache-chunk-key.patch
+++ b/leaf-server/minecraft-patches/features/0173-Cache-chunk-key.patch
@@ -119,10 +119,10 @@ index 63cc7970b9df5e84743084ca99650bc3d13b970e..022dd571623224fd87c4aa4a50ebdba4
          // Paper end - rewrite chunk system
      }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 00dc14586fd48416da67c22ce7575383876e4b1e..9c945a10f096cbf10a8a77e653b24e0306de02c3 100644
+index 8c7398aaf0d1964b94d69da8b3c8594f2d07a46f..01963b063f232b6e33842c11168b2c5ccd38e025 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -550,7 +550,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -551,7 +551,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public final void moonrise$markChunkForPlayerTicking(final LevelChunk chunk) {
          final ChunkPos pos = chunk.getPos();
@@ -131,7 +131,7 @@ index 00dc14586fd48416da67c22ce7575383876e4b1e..9c945a10f096cbf10a8a77e653b24e03
              return;
          }
  
-@@ -2825,7 +2825,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2827,7 +2827,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean areEntitiesActuallyLoadedAndTicking(final ChunkPos pos) {
          // Paper start - rewrite chunk system
@@ -140,7 +140,7 @@ index 00dc14586fd48416da67c22ce7575383876e4b1e..9c945a10f096cbf10a8a77e653b24e03
          return chunkHolder != null && chunkHolder.isEntityTickingReady();
          // Paper end - rewrite chunk system
      }
-@@ -2845,7 +2845,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2847,7 +2847,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean canSpawnEntitiesInChunk(final ChunkPos pos) {
          // Paper start - rewrite chunk system

--- a/leaf-server/minecraft-patches/features/0173-Cache-chunk-key.patch
+++ b/leaf-server/minecraft-patches/features/0173-Cache-chunk-key.patch
@@ -119,10 +119,10 @@ index 63cc7970b9df5e84743084ca99650bc3d13b970e..022dd571623224fd87c4aa4a50ebdba4
          // Paper end - rewrite chunk system
      }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6cc37813c571cd5a4a7bb6e97de4956ed7c0e121..4bca5b3b368cda2229522c9ab2af3116b08f91a7 100644
+index 00dc14586fd48416da67c22ce7575383876e4b1e..9c945a10f096cbf10a8a77e653b24e0306de02c3 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -549,7 +549,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -550,7 +550,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      @Override
      public final void moonrise$markChunkForPlayerTicking(final LevelChunk chunk) {
          final ChunkPos pos = chunk.getPos();
@@ -131,7 +131,7 @@ index 6cc37813c571cd5a4a7bb6e97de4956ed7c0e121..4bca5b3b368cda2229522c9ab2af3116
              return;
          }
  
-@@ -2823,7 +2823,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2825,7 +2825,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean areEntitiesActuallyLoadedAndTicking(final ChunkPos pos) {
          // Paper start - rewrite chunk system
@@ -140,7 +140,7 @@ index 6cc37813c571cd5a4a7bb6e97de4956ed7c0e121..4bca5b3b368cda2229522c9ab2af3116
          return chunkHolder != null && chunkHolder.isEntityTickingReady();
          // Paper end - rewrite chunk system
      }
-@@ -2843,7 +2843,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2845,7 +2845,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      public boolean canSpawnEntitiesInChunk(final ChunkPos pos) {
          // Paper start - rewrite chunk system

--- a/leaf-server/minecraft-patches/features/0183-optimize-mob-despawn.patch
+++ b/leaf-server/minecraft-patches/features/0183-optimize-mob-despawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] optimize mob despawn
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 9c945a10f096cbf10a8a77e653b24e0306de02c3..2bbea8867b82061a97b67a3bbd4903334b3d9ae7 100644
+index 01963b063f232b6e33842c11168b2c5ccd38e025..722a25e2cec912331616ac585f4704236a6af11e 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -905,6 +905,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -907,6 +907,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              }
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
@@ -16,7 +16,7 @@ index 9c945a10f096cbf10a8a77e653b24e0306de02c3..2bbea8867b82061a97b67a3bbd490333
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -912,7 +913,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -914,7 +915,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                          if (!entity.isRemoved()) {
                              if (!tickRateManager.isEntityFrozen(entity)) {
                                  profiler.push("checkDespawn");
@@ -25,7 +25,7 @@ index 9c945a10f096cbf10a8a77e653b24e0306de02c3..2bbea8867b82061a97b67a3bbd490333
                                  profiler.pop();
                                  if (true) { // Paper - rewrite chunk system
                                      Entity vehicle = entity.getVehicle();
-@@ -1046,6 +1047,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1048,6 +1049,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper end - optimise random ticking
  

--- a/leaf-server/minecraft-patches/features/0183-optimize-mob-despawn.patch
+++ b/leaf-server/minecraft-patches/features/0183-optimize-mob-despawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] optimize mob despawn
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 4bca5b3b368cda2229522c9ab2af3116b08f91a7..fdba2c55ca108a3ff467e4cc84320f451f4151f4 100644
+index 9c945a10f096cbf10a8a77e653b24e0306de02c3..2bbea8867b82061a97b67a3bbd4903334b3d9ae7 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -903,6 +903,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -905,6 +905,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              }
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
@@ -16,7 +16,7 @@ index 4bca5b3b368cda2229522c9ab2af3116b08f91a7..fdba2c55ca108a3ff467e4cc84320f45
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -910,7 +911,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -912,7 +913,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                          if (!entity.isRemoved()) {
                              if (!tickRateManager.isEntityFrozen(entity)) {
                                  profiler.push("checkDespawn");
@@ -25,7 +25,7 @@ index 4bca5b3b368cda2229522c9ab2af3116b08f91a7..fdba2c55ca108a3ff467e4cc84320f45
                                  profiler.pop();
                                  if (true) { // Paper - rewrite chunk system
                                      Entity vehicle = entity.getVehicle();
-@@ -1044,6 +1045,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1046,6 +1047,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper end - optimise random ticking
  

--- a/leaf-server/minecraft-patches/features/0191-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/minecraft-patches/features/0191-SparklyPaper-Parallel-world-ticking.patch
@@ -365,7 +365,7 @@ index aa30556730b3c924f72ccd8702a88c380d42c6a9..d9d0a7693e86c244af47513ae1a3e39e
                  continue;
              }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bcd50829d3 100644
+index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b889ee8bdbd 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -196,7 +196,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -389,7 +389,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
  
      // CraftBukkit start
      private final ResourceKey<LevelStem> typeKey;
-@@ -763,6 +768,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -765,6 +770,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - rewrite chunk system
          this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
          this.realPlayers = Lists.newArrayList(); // Leaves - skip
@@ -405,7 +405,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
      }
  
      // Paper start
-@@ -816,10 +830,147 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -818,10 +832,147 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return previous;
      }
  
@@ -553,7 +553,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
          TickRateManager tickRateManager = this.tickRateManager();
          boolean runs = tickRateManager.runsNormally();
          if (runs) {
-@@ -830,6 +981,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -832,6 +983,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              profiler.pop();
          }
  
@@ -566,7 +566,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
          int percentage = this.getGameRules().get(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
          if (this.purpurConfig.playersSkipNight && this.sleepStatus.areEnoughSleeping(percentage) && this.sleepStatus.areEnoughDeepSleeping(percentage, this.players)) { // Purpur - Config for skipping night
              Optional<Holder<WorldClock>> defaultClock = this.dimensionType().defaultClock();
-@@ -935,6 +1092,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -937,6 +1094,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                                          entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
                                          // Paper end - Prevent block entity and entity crashes
                                      }
@@ -574,7 +574,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
                                      this.moonrise$midTickTasks(); // Paper - rewrite chunk system
                                      // Gale end - Airplane - remove lambda from ticking guard - copied from guardEntityTick
                                      profiler.pop();
-@@ -1442,7 +1600,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1444,7 +1602,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              fluidState.tick(this, pos, blockState);
          }
          // Paper start - rewrite chunk system
@@ -586,7 +586,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
              ((ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer)this.server).moonrise$executeMidTickTasks();
          }
          // Paper end - rewrite chunk system
-@@ -1455,7 +1616,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1457,7 +1618,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              state.tick(this, pos, this.random);
          }
          // Paper start - rewrite chunk system
@@ -598,7 +598,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
              ((ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer)this.server).moonrise$executeMidTickTasks();
          }
          // Paper end - rewrite chunk system
-@@ -1707,6 +1871,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1709,6 +1873,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      private void addPlayer(final ServerPlayer player) {
@@ -606,7 +606,7 @@ index fdba2c55ca108a3ff467e4cc84320f451f4151f4..d3d962689505b906767348898c9461bc
          Entity existing = this.getEntity(player.getUUID());
          if (existing != null) {
              LOGGER.warn("Force-added player with duplicate UUID {}", player.getUUID());
-@@ -1719,7 +1884,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1721,7 +1886,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      // CraftBukkit start
      private boolean addEntity(final Entity entity, final org.bukkit.event.entity.CreatureSpawnEvent.@Nullable SpawnReason spawnReason) {

--- a/leaf-server/minecraft-patches/features/0191-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/minecraft-patches/features/0191-SparklyPaper-Parallel-world-ticking.patch
@@ -121,7 +121,7 @@ index aa5bebc293a73468cadf7939fd0a64822953e452..eb5d5b31329a5c6420556966e7fd1ac1
                  // Paper end
                  // CraftBukkit start
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe78806fa326d8 100644
+index a2023539e70402a25d7d5452f63c6d734e9d374a..a4b2b0bc1bac3625b91536d9a1379a945cd66747 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -340,6 +340,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -175,7 +175,7 @@ index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe7880
          }
  
          return executed;
-@@ -987,6 +999,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -994,6 +1006,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
  
              level.save(null, flush, SharedConstants.DEBUG_DONT_SAVE_WORLD || level.noSave && !force, close); // Paper - add close param
@@ -188,7 +188,7 @@ index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe7880
              result = true;
          }
  
-@@ -1847,6 +1865,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1854,6 +1872,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      public final io.papermc.paper.threadedregions.EntityScheduler.EntitySchedulerTickList entitySchedulerTickList = new io.papermc.paper.threadedregions.EntityScheduler.EntitySchedulerTickList(); // Paper - optimise Folia entity scheduler
  
@@ -207,7 +207,7 @@ index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe7880
      protected void tickChildren(final BooleanSupplier haveTime) {
          ProfilerFiller profiler = Profiler.get();
          this.getPlayerList().getPlayers().forEach(playerx -> playerx.connection.suspendFlushing());
-@@ -1897,6 +1927,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1904,6 +1934,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.updateEffectiveRespawnData();
  
          this.isIteratingOverLevels = true; // Paper - Throw exception on world create while being ticked
@@ -217,7 +217,7 @@ index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe7880
          for (ServerLevel level : this.getAllLevels()) {
              level.hasPhysicsEvent = org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - BlockPhysicsEvent
              level.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
-@@ -1906,18 +1939,34 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1913,18 +1946,34 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              profiler.push(() -> level + " " + level.dimension().identifier());
              profiler.push("tick");
  
@@ -258,7 +258,7 @@ index 53dfd4a95746d57a214da982a76cd0e847d27d60..ad5eaa73a0b491c0e482a20cccbe7880
          this.isIteratingOverLevels = false; // Paper - Throw exception on world create while being ticked
  
          profiler.popPush("connection");
-@@ -2010,6 +2059,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2017,6 +2066,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          Map<ResourceKey<Level>, ServerLevel> oldLevels = this.levels;
          Map<ResourceKey<Level>, ServerLevel> newLevels = Maps.newLinkedHashMap(oldLevels);
          newLevels.remove(level.dimension());
@@ -365,7 +365,7 @@ index aa30556730b3c924f72ccd8702a88c380d42c6a9..d9d0a7693e86c244af47513ae1a3e39e
                  continue;
              }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b889ee8bdbd 100644
+index 722a25e2cec912331616ac585f4704236a6af11e..445ca02f6d27d6f4968e9af63c89acd60fb32d73 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -196,7 +196,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -389,7 +389,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
  
      // CraftBukkit start
      private final ResourceKey<LevelStem> typeKey;
-@@ -765,6 +770,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -767,6 +772,15 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - rewrite chunk system
          this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
          this.realPlayers = Lists.newArrayList(); // Leaves - skip
@@ -405,7 +405,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
      }
  
      // Paper start
-@@ -818,10 +832,147 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -820,10 +834,147 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return previous;
      }
  
@@ -553,7 +553,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
          TickRateManager tickRateManager = this.tickRateManager();
          boolean runs = tickRateManager.runsNormally();
          if (runs) {
-@@ -832,6 +983,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -834,6 +985,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              profiler.pop();
          }
  
@@ -566,7 +566,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
          int percentage = this.getGameRules().get(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
          if (this.purpurConfig.playersSkipNight && this.sleepStatus.areEnoughSleeping(percentage) && this.sleepStatus.areEnoughDeepSleeping(percentage, this.players)) { // Purpur - Config for skipping night
              Optional<Holder<WorldClock>> defaultClock = this.dimensionType().defaultClock();
-@@ -937,6 +1094,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -939,6 +1096,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                                          entity.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DISCARD);
                                          // Paper end - Prevent block entity and entity crashes
                                      }
@@ -574,7 +574,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
                                      this.moonrise$midTickTasks(); // Paper - rewrite chunk system
                                      // Gale end - Airplane - remove lambda from ticking guard - copied from guardEntityTick
                                      profiler.pop();
-@@ -1444,7 +1602,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1446,7 +1604,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              fluidState.tick(this, pos, blockState);
          }
          // Paper start - rewrite chunk system
@@ -586,7 +586,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
              ((ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer)this.server).moonrise$executeMidTickTasks();
          }
          // Paper end - rewrite chunk system
-@@ -1457,7 +1618,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1459,7 +1620,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
              state.tick(this, pos, this.random);
          }
          // Paper start - rewrite chunk system
@@ -598,7 +598,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
              ((ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer)this.server).moonrise$executeMidTickTasks();
          }
          // Paper end - rewrite chunk system
-@@ -1709,6 +1873,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1711,6 +1875,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
  
      private void addPlayer(final ServerPlayer player) {
@@ -606,7 +606,7 @@ index 2bbea8867b82061a97b67a3bbd4903334b3d9ae7..6435afbe37ce77a2c82fceb83e8d9b88
          Entity existing = this.getEntity(player.getUUID());
          if (existing != null) {
              LOGGER.warn("Force-added player with duplicate UUID {}", player.getUUID());
-@@ -1721,7 +1886,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1723,7 +1888,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      // CraftBukkit start
      private boolean addEntity(final Entity entity, final org.bukkit.event.entity.CreatureSpawnEvent.@Nullable SpawnReason spawnReason) {

--- a/leaf-server/minecraft-patches/features/0192-SparklyPaper-Track-each-world-MSPT.patch
+++ b/leaf-server/minecraft-patches/features/0192-SparklyPaper-Track-each-world-MSPT.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] SparklyPaper: Track each world MSPT
 Original project: https://github.com/SparklyPower/SparklyPaper
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index ad5eaa73a0b491c0e482a20cccbe78806fa326d8..cb21a88822126f4e199dcbc0a464903e01a6e1e7 100644
+index a4b2b0bc1bac3625b91536d9a1379a945cd66747..3767d8d2eef6138164356c61df8d47de471abe3e 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1868,7 +1868,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1875,7 +1875,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // Leaf start - SparklyPaper - parallel world ticking - move level ticking logic out for branch convergence
      private void tickLevel(final ServerLevel level, final BooleanSupplier haveTime) {
          try {
@@ -27,10 +27,10 @@ index ad5eaa73a0b491c0e482a20cccbe78806fa326d8..cb21a88822126f4e199dcbc0a464903e
              CrashReport report = CrashReport.forThrowable(t, "Exception ticking world");
              level.fillReportDetails(report);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6435afbe37ce77a2c82fceb83e8d9b889ee8bdbd..86b244e061076e0c508f871b9ff256ac64b859e0 100644
+index 445ca02f6d27d6f4968e9af63c89acd60fb32d73..d9e62989f3fe62b9436074f8de5ed32d8214df66 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -615,6 +615,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -616,6 +616,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper end - chunk tick iteration
  

--- a/leaf-server/minecraft-patches/features/0192-SparklyPaper-Track-each-world-MSPT.patch
+++ b/leaf-server/minecraft-patches/features/0192-SparklyPaper-Track-each-world-MSPT.patch
@@ -27,10 +27,10 @@ index ad5eaa73a0b491c0e482a20cccbe78806fa326d8..cb21a88822126f4e199dcbc0a464903e
              CrashReport report = CrashReport.forThrowable(t, "Exception ticking world");
              level.fillReportDetails(report);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d3d962689505b906767348898c9461bcd50829d3..e7815ca0ef0a03d70850a23de591615675df8ece 100644
+index 6435afbe37ce77a2c82fceb83e8d9b889ee8bdbd..86b244e061076e0c508f871b9ff256ac64b859e0 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -614,6 +614,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -615,6 +615,12 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper end - chunk tick iteration
  

--- a/leaf-server/minecraft-patches/features/0196-Use-BFS-on-getSlopeDistance.patch
+++ b/leaf-server/minecraft-patches/features/0196-Use-BFS-on-getSlopeDistance.patch
@@ -9,10 +9,10 @@ Leaf: ~48ms (-36%)
 This should help drastically on the farms that use actively changing fluids.
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index e7815ca0ef0a03d70850a23de591615675df8ece..cd7883d18511c2f5ce73f41afd676da0ee2d86ff 100644
+index 86b244e061076e0c508f871b9ff256ac64b859e0..78e82ba68c24a68e0a86c5332393f35e80a44c93 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1599,6 +1599,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1601,6 +1601,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.emptyTime = 0;
      }
  

--- a/leaf-server/minecraft-patches/features/0196-Use-BFS-on-getSlopeDistance.patch
+++ b/leaf-server/minecraft-patches/features/0196-Use-BFS-on-getSlopeDistance.patch
@@ -9,10 +9,10 @@ Leaf: ~48ms (-36%)
 This should help drastically on the farms that use actively changing fluids.
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 86b244e061076e0c508f871b9ff256ac64b859e0..78e82ba68c24a68e0a86c5332393f35e80a44c93 100644
+index d9e62989f3fe62b9436074f8de5ed32d8214df66..c94fac94b1a7a71cadf1a7841b682fee25a79535 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1601,6 +1601,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1603,6 +1603,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.emptyTime = 0;
      }
  

--- a/leaf-server/minecraft-patches/features/0211-Protocol-Core.patch
+++ b/leaf-server/minecraft-patches/features/0211-Protocol-Core.patch
@@ -22,10 +22,10 @@ index 2f1e5c3de421bd07e30c417bf88935be85cf573c..702d368bb5cf11863197b92d17f03738
              }
  
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index cb21a88822126f4e199dcbc0a464903e01a6e1e7..bac03e83020cd38bd2553c7db04487d91828df1d 100644
+index 3767d8d2eef6138164356c61df8d47de471abe3e..481de7a3db556489d7f9e92de8faca94a580c060 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1992,6 +1992,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1999,6 +1999,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          profiler.popPush("server gui refresh");
  
          org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(tickCount); // Leaves - protocol
@@ -46,7 +46,7 @@ index 16912d01ce0c943268290d382e50f3b0c63b40a1..dc1f4fcbd284735f8c98cd2f60095a89
  
      private void updatePlayerAttributes() {
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 36cd6537f55ae713afbec15e17c409dee515600b..bfa522910ce7e9cb83668b69fa4c40daec8ab910 100644
+index ead9431fbdd3a7311d3378328af98d6d9be885fa..1c0b616aa34e93e015267fc2415d00431ad494d7 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -186,6 +186,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack

--- a/leaf-server/minecraft-patches/features/0221-Cache-block-state-tags.patch
+++ b/leaf-server/minecraft-patches/features/0221-Cache-block-state-tags.patch
@@ -9,10 +9,10 @@ so that custom things injected by plugins, CraftEngine, for example, will not be
 So we need to init it again after the plugin loads (Double init, but it doesn't matter)
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index bac03e83020cd38bd2553c7db04487d91828df1d..7d43201ad4b66209c31f69c32a0d88590aae906c 100644
+index 481de7a3db556489d7f9e92de8faca94a580c060..a04608fc3b5d6fdc1af5ff5eb2cfa3d21114593e 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1365,6 +1365,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1372,6 +1372,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // Paper end
              org.spigotmc.WatchdogThread.hasStarted = true; // Paper
              org.dreeam.leaf.config.LeafConfig.regSparkExtraConfig(); // Leaf - Leaf config

--- a/leaf-server/minecraft-patches/features/0226-optimize-mob-spawning.patch
+++ b/leaf-server/minecraft-patches/features/0226-optimize-mob-spawning.patch
@@ -191,10 +191,10 @@ index d9d0a7693e86c244af47513ae1a3e39e2bb63a31..b80b408d8b087e37b06e9ad4c096e0b6
              }
          }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index cd7883d18511c2f5ce73f41afd676da0ee2d86ff..8bfa430a066da88af2af0bc470768cc338072659 100644
+index 78e82ba68c24a68e0a86c5332393f35e80a44c93..df8d1c134b30a4c9115790a33364361736d8bf15 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1210,6 +1210,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1212,6 +1212,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper end - optimise random ticking
  
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn

--- a/leaf-server/minecraft-patches/features/0226-optimize-mob-spawning.patch
+++ b/leaf-server/minecraft-patches/features/0226-optimize-mob-spawning.patch
@@ -16,7 +16,7 @@ Generally faster than the non-async approach
 iterate over all entities, get their chunk, and increment the count
 
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 7bc1636e8ae526e7ffbb8b34b3b777b6f407f0b4..13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711 100644
+index 9d634e5e0405a1fc1e8b9011b2eb8d681073949a..094f6af25bcae20d1b56687721485f0cb8b260aa 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -275,6 +275,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -191,10 +191,10 @@ index d9d0a7693e86c244af47513ae1a3e39e2bb63a31..b80b408d8b087e37b06e9ad4c096e0b6
              }
          }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 78e82ba68c24a68e0a86c5332393f35e80a44c93..df8d1c134b30a4c9115790a33364361736d8bf15 100644
+index c94fac94b1a7a71cadf1a7841b682fee25a79535..2275b2341a50173eeab52fc0a684c609a28a99db 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1212,6 +1212,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1214,6 +1214,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper end - optimise random ticking
  
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn

--- a/leaf-server/minecraft-patches/features/0227-optimize-structure-map.patch
+++ b/leaf-server/minecraft-patches/features/0227-optimize-structure-map.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] optimize structure map
 
 
 diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
-index dd4f4fe9f36e16b2014f66fbdb684b5ebb226fa7..0c704d58e648b14ffbc6db40b5e1b269227ad5ed 100644
+index fb33c44ed66260d74696af5484b2566630b25fbe..e6862e539a1974cdc15fb6e65186743e73071b8b 100644
 --- a/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/net/minecraft/world/level/chunk/ChunkAccess.java
 @@ -73,8 +73,8 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
@@ -19,7 +19,7 @@ index dd4f4fe9f36e16b2014f66fbdb684b5ebb226fa7..0c704d58e648b14ffbc6db40b5e1b269
      protected final Map<BlockPos, CompoundTag> pendingBlockEntities = Maps.newHashMap();
      public final Map<BlockPos, BlockEntity> blockEntities = new Object2ObjectOpenHashMap<>();
      protected final LevelHeightAccessor levelHeightAccessor;
-@@ -293,7 +293,7 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
+@@ -301,7 +301,7 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
      }
  
      public Map<Structure, StructureStart> getAllStarts() {
@@ -28,7 +28,7 @@ index dd4f4fe9f36e16b2014f66fbdb684b5ebb226fa7..0c704d58e648b14ffbc6db40b5e1b269
      }
  
      public void setAllStarts(final Map<Structure, StructureStart> starts) {
-@@ -309,13 +309,13 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
+@@ -317,13 +317,13 @@ public abstract class ChunkAccess implements LightChunk, StructureAccess, BiomeM
  
      @Override
      public void addReferenceForStructure(final Structure structure, final long reference) {

--- a/leaf-server/minecraft-patches/features/0233-optimize-random-tick.patch
+++ b/leaf-server/minecraft-patches/features/0233-optimize-random-tick.patch
@@ -24,10 +24,10 @@ index b80b408d8b087e37b06e9ad4c096e0b6cb7c0a86..78ec485515b53a4d61d577b4a688f127
              profiler.popPush("customSpawners");
              this.level.tickCustomSpawners(this.spawnEnemies);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index df8d1c134b30a4c9115790a33364361736d8bf15..cbd825792b41c8bf6ea5cc1635bc0b44ca30e007 100644
+index 2275b2341a50173eeab52fc0a684c609a28a99db..56fd136abddb4bfda581207df58ea8fa867e9b2f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1213,6 +1213,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1215,6 +1215,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning

--- a/leaf-server/minecraft-patches/features/0233-optimize-random-tick.patch
+++ b/leaf-server/minecraft-patches/features/0233-optimize-random-tick.patch
@@ -24,10 +24,10 @@ index b80b408d8b087e37b06e9ad4c096e0b6cb7c0a86..78ec485515b53a4d61d577b4a688f127
              profiler.popPush("customSpawners");
              this.level.tickCustomSpawners(this.spawnEnemies);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8bfa430a066da88af2af0bc470768cc338072659..a127bf1fcdc71f821685099646a4846c08b7581a 100644
+index df8d1c134b30a4c9115790a33364361736d8bf15..cbd825792b41c8bf6ea5cc1635bc0b44ca30e007 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1211,6 +1211,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1213,6 +1213,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning

--- a/leaf-server/minecraft-patches/features/0234-cache-biome-zoom-seed.patch
+++ b/leaf-server/minecraft-patches/features/0234-cache-biome-zoom-seed.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] cache biome zoom seed
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 7d43201ad4b66209c31f69c32a0d88590aae906c..c6a6babf3329dd7b622bd84b1d5446b952c6740b 100644
+index a04608fc3b5d6fdc1af5ff5eb2cfa3d21114593e..9146f58c0f232f1d38665596e1ae92b757a38509 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -724,8 +724,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -32,12 +32,12 @@ index c8a95d67dbe687fad6086e13fab0087b8ed715e1..4030776c3d12f8e797720180e141322b
              this.gameMode.getPreviousGameModeForPlayer(),
              level.isDebug(),
 diff --git a/net/minecraft/server/level/WorldGenRegion.java b/net/minecraft/server/level/WorldGenRegion.java
-index 015539951e2a6af0e7b50c05512d1f6200ef2797..1049e948496fcbab5f3d5789ec1e975692309a36 100644
+index 0626af0efa86ac0d464f261e0ac1b96ba7de965b..da37b831e121c8e93666af51d6428ec6149b0530 100644
 --- a/net/minecraft/server/level/WorldGenRegion.java
 +++ b/net/minecraft/server/level/WorldGenRegion.java
 @@ -118,7 +118,7 @@ public class WorldGenRegion implements WorldGenLevel {
          this.levelData = level.getLevelData();
-         this.random = level.getChunkSource().randomState().getOrCreateRandomFactory(WORLDGEN_REGION_RANDOM).at(this.center.getPos().getWorldPosition());
+         this.random = level.getChunkSource().randomState().getOrCreateWorldgenRandomFactory(WORLDGEN_REGION_RANDOM).at(this.center.getPos().getWorldPosition()); // Leaf - Matter - Secure Seed
          this.dimensionType = level.dimensionType();
 -        this.biomeManager = new BiomeManager(this, BiomeManager.obfuscateSeed(this.seed));
 +        this.biomeManager = new BiomeManager(this, level.worldGenSettings.options().biomeZoomSeed()); // Leaf - cache biome zoom seed
@@ -45,22 +45,23 @@ index 015539951e2a6af0e7b50c05512d1f6200ef2797..1049e948496fcbab5f3d5789ec1e9756
          this.centerChunkX = centerPos.x();
          this.centerChunkZ = centerPos.z();
 diff --git a/net/minecraft/world/level/levelgen/WorldOptions.java b/net/minecraft/world/level/levelgen/WorldOptions.java
-index b23dd531d284647e614f07f134c41e70593d5c04..4d58651cbaedb3035b7d8d8f367afc3f980da295 100644
+index e43ce4992f5d3842c4e44b71644919c8efed1dcf..42f19c4f18794f89fd7f5af26afbf68574271c60 100644
 --- a/net/minecraft/world/level/levelgen/WorldOptions.java
 +++ b/net/minecraft/world/level/levelgen/WorldOptions.java
-@@ -38,6 +38,7 @@ public class WorldOptions {
+@@ -43,6 +43,7 @@ public class WorldOptions {
          : new WorldOptions("North Carolina".hashCode(), true, true);
      // Leaf end - Matter - Secure Seed
      private final long seed;
 +    private final long biomeZoomSeed; // Leaf - cache biome zoom seed
      private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed(); // Leaf - Matter - Secure Seed
+     private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto; // Leaf - HMAC secure terrain
      private final boolean generateStructures;
-     private final boolean generateBonusChest;
-@@ -79,8 +80,15 @@ public class WorldOptions {
+@@ -93,9 +94,16 @@ public class WorldOptions {
          this.generateStructures = generateStructures;
          this.generateBonusChest = generateBonusChest;
          this.legacyCustomOptions = legacyCustomOptions;
 +        this.biomeZoomSeed = net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(seed); // Leaf - cache biome zoom seed
+         this.terrainCrypto = terrainCrypto; // Leaf - Matter - Secure Seed
      }
  
 +    // Leaf start - cache biome zoom seed

--- a/leaf-server/minecraft-patches/features/0234-cache-biome-zoom-seed.patch
+++ b/leaf-server/minecraft-patches/features/0234-cache-biome-zoom-seed.patch
@@ -45,17 +45,17 @@ index 0626af0efa86ac0d464f261e0ac1b96ba7de965b..da37b831e121c8e93666af51d6428ec6
          this.centerChunkX = centerPos.x();
          this.centerChunkZ = centerPos.z();
 diff --git a/net/minecraft/world/level/levelgen/WorldOptions.java b/net/minecraft/world/level/levelgen/WorldOptions.java
-index e43ce4992f5d3842c4e44b71644919c8efed1dcf..42f19c4f18794f89fd7f5af26afbf68574271c60 100644
+index 5c061cb8382995d3e768a60617f01f82d2bdbf69..5fbf706d681773309e7a62b34051d34c1447691b 100644
 --- a/net/minecraft/world/level/levelgen/WorldOptions.java
 +++ b/net/minecraft/world/level/levelgen/WorldOptions.java
-@@ -43,6 +43,7 @@ public class WorldOptions {
-         : new WorldOptions("North Carolina".hashCode(), true, true);
+@@ -45,6 +45,7 @@ public class WorldOptions {
+     private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto;
      // Leaf end - Matter - Secure Seed
      private final long seed;
 +    private final long biomeZoomSeed; // Leaf - cache biome zoom seed
-     private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed(); // Leaf - Matter - Secure Seed
-     private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCrypto terrainCrypto; // Leaf - HMAC secure terrain
      private final boolean generateStructures;
+     private final boolean generateBonusChest;
+     private final Optional<String> legacyCustomOptions;
 @@ -93,9 +94,16 @@ public class WorldOptions {
          this.generateStructures = generateStructures;
          this.generateBonusChest = generateBonusChest;

--- a/leaf-server/minecraft-patches/features/0238-Paw-optimization.patch
+++ b/leaf-server/minecraft-patches/features/0238-Paw-optimization.patch
@@ -81,10 +81,10 @@ index 78ec485515b53a4d61d577b4a688f12722655cf9..b26d7cbe440abf35952c1bab3a2487cf
              profiler.popPush("tickSpawningChunks");
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index a127bf1fcdc71f821685099646a4846c08b7581a..acc05a34b5ade35e4fbba1c9bc5987c081b843b3 100644
+index cbd825792b41c8bf6ea5cc1635bc0b44ca30e007..d7dd8125327a27c352486b58f50651ea62c887b6 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1638,26 +1638,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1640,26 +1640,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      }
  
@@ -111,7 +111,7 @@ index a127bf1fcdc71f821685099646a4846c08b7581a..acc05a34b5ade35e4fbba1c9bc5987c0
          entity.setOldPosAndRot();
          ProfilerFiller profiler = Profiler.get();
          entity.tickCount++;
-@@ -1674,13 +1656,6 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1676,13 +1658,6 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          for (Entity passenger : entity.getPassengers()) {
              this.tickPassenger(entity, passenger, isActive); // Paper - EAR 2
          }

--- a/leaf-server/minecraft-patches/features/0238-Paw-optimization.patch
+++ b/leaf-server/minecraft-patches/features/0238-Paw-optimization.patch
@@ -81,10 +81,10 @@ index 78ec485515b53a4d61d577b4a688f12722655cf9..b26d7cbe440abf35952c1bab3a2487cf
              profiler.popPush("tickSpawningChunks");
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index cbd825792b41c8bf6ea5cc1635bc0b44ca30e007..d7dd8125327a27c352486b58f50651ea62c887b6 100644
+index 56fd136abddb4bfda581207df58ea8fa867e9b2f..0d7b3c4247a0b340a10ca2ea5e8b15e5d3bb52b6 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1640,26 +1640,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1642,26 +1642,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      }
  
@@ -111,7 +111,7 @@ index cbd825792b41c8bf6ea5cc1635bc0b44ca30e007..d7dd8125327a27c352486b58f50651ea
          entity.setOldPosAndRot();
          ProfilerFiller profiler = Profiler.get();
          entity.tickCount++;
-@@ -1676,13 +1658,6 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1678,13 +1660,6 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          for (Entity passenger : entity.getPassengers()) {
              this.tickPassenger(entity, passenger, isActive); // Paper - EAR 2
          }

--- a/leaf-server/minecraft-patches/features/0247-Paper-PR-Optimise-temptation-lookups.patch
+++ b/leaf-server/minecraft-patches/features/0247-Paper-PR-Optimise-temptation-lookups.patch
@@ -113,10 +113,10 @@ index 0000000000000000000000000000000000000000..c3339b22929cb4e3b216aadf1069daa1
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d7dd8125327a27c352486b58f50651ea62c887b6..6ffa3673635f6548673cff8082e9009eb4229eda 100644
+index 0d7b3c4247a0b340a10ca2ea5e8b15e5d3bb52b6..687237128f1da53c03613dab29af64297182be83 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1069,6 +1069,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1071,6 +1071,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
              boolean didDespawn = tickRateManager.runsNormally() && despawnMap.tick(this, this.entityTickList); // Leaf - optimize despawn
@@ -124,7 +124,7 @@ index d7dd8125327a27c352486b58f50651ea62c887b6..6ffa3673635f6548673cff8082e9009e
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -3295,4 +3296,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -3297,4 +3298,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
      }
      // Paper end - lag compensation

--- a/leaf-server/minecraft-patches/features/0247-Paper-PR-Optimise-temptation-lookups.patch
+++ b/leaf-server/minecraft-patches/features/0247-Paper-PR-Optimise-temptation-lookups.patch
@@ -113,10 +113,10 @@ index 0000000000000000000000000000000000000000..c3339b22929cb4e3b216aadf1069daa1
 +    }
 +}
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index acc05a34b5ade35e4fbba1c9bc5987c081b843b3..29bc5c4bbec66562888758157685645f5922841c 100644
+index d7dd8125327a27c352486b58f50651ea62c887b6..6ffa3673635f6548673cff8082e9009eb4229eda 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1067,6 +1067,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1069,6 +1069,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
              boolean didDespawn = tickRateManager.runsNormally() && despawnMap.tick(this, this.entityTickList); // Leaf - optimize despawn
@@ -124,7 +124,7 @@ index acc05a34b5ade35e4fbba1c9bc5987c081b843b3..29bc5c4bbec66562888758157685645f
              this.entityTickList
                  .forEach(
                      entity -> {
-@@ -3293,4 +3294,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -3295,4 +3296,11 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.lagCompensationTick = (System.nanoTime() - MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
      }
      // Paper end - lag compensation

--- a/leaf-server/minecraft-patches/features/0248-Paper-PR-Optimise-temptation-lookups-changes.patch
+++ b/leaf-server/minecraft-patches/features/0248-Paper-PR-Optimise-temptation-lookups-changes.patch
@@ -95,10 +95,10 @@ index c3339b22929cb4e3b216aadf1069daa1f792d74e..3a9fb2524df84fe332eb94c3efe22876
 +    // Leaf end - Paper PR: Optimise temptation lookups changes
  }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6ffa3673635f6548673cff8082e9009eb4229eda..8e4a1780ae472f953bd7bb354f306baac3bea46a 100644
+index 687237128f1da53c03613dab29af64297182be83..96e44c5af458218bb55b4784c7e081440a56bb32 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1069,7 +1069,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1071,7 +1071,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
              boolean didDespawn = tickRateManager.runsNormally() && despawnMap.tick(this, this.entityTickList); // Leaf - optimize despawn

--- a/leaf-server/minecraft-patches/features/0248-Paper-PR-Optimise-temptation-lookups-changes.patch
+++ b/leaf-server/minecraft-patches/features/0248-Paper-PR-Optimise-temptation-lookups-changes.patch
@@ -95,10 +95,10 @@ index c3339b22929cb4e3b216aadf1069daa1f792d74e..3a9fb2524df84fe332eb94c3efe22876
 +    // Leaf end - Paper PR: Optimise temptation lookups changes
  }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 29bc5c4bbec66562888758157685645f5922841c..ea1af07226c9b0d20f0edb5b97786d42a4c4eece 100644
+index 6ffa3673635f6548673cff8082e9009eb4229eda..8e4a1780ae472f953bd7bb354f306baac3bea46a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1067,7 +1067,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1069,7 +1069,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
              io.papermc.paper.entity.activation.ActivationRange.activateEntities(this); // Paper - EAR
              boolean didDespawn = tickRateManager.runsNormally() && despawnMap.tick(this, this.entityTickList); // Leaf - optimize despawn

--- a/leaf-server/minecraft-patches/features/0254-thread-unsafe-chunk-map.patch
+++ b/leaf-server/minecraft-patches/features/0254-thread-unsafe-chunk-map.patch
@@ -81,10 +81,10 @@ index a4dcd20aa70639c1291f1a01c702008a406449f8..a2bccd6a339a5faf64f2b5d47b7aacc3
  
      // note: never call while inside the chunk system, this will absolutely break everything
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index c6a6babf3329dd7b622bd84b1d5446b952c6740b..afaed2c11ec1058c9f148362c3f657644e8e0e41 100644
+index 9146f58c0f232f1d38665596e1ae92b757a38509..2ff0c52496ebaa714aaa4a643314c8947342b409 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1952,6 +1952,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1959,6 +1959,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  serverLevelTickingSemaphore.acquire();
                  tasks.add(
                      level.tickExecutor.submit(() -> {
@@ -93,7 +93,7 @@ index c6a6babf3329dd7b622bd84b1d5446b952c6740b..afaed2c11ec1058c9f148362c3f65764
                          ca.spottedleaf.moonrise.common.util.TickThread.ServerLevelTickThread currentThread = (ca.spottedleaf.moonrise.common.util.TickThread.ServerLevelTickThread) Thread.currentThread();
                          currentThread.currentTickingServerLevel = level;
                          try {
-@@ -1970,7 +1972,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1977,7 +1979,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              level.explosionDensityCache.clear(); // Paper - Optimize explosions
          }
              while (!tasks.isEmpty()) {

--- a/leaf-server/minecraft-patches/features/0266-cache-collision-list.patch
+++ b/leaf-server/minecraft-patches/features/0266-cache-collision-list.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] cache collision list
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8e4a1780ae472f953bd7bb354f306baac3bea46a..5e4bbdb3ca4acd9c69884aea3c17317a62397e16 100644
+index 96e44c5af458218bb55b4784c7e081440a56bb32..30ecebf3d19cf0056d86ec5368978ee1bd98e5fe 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1215,6 +1215,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1217,6 +1217,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick

--- a/leaf-server/minecraft-patches/features/0266-cache-collision-list.patch
+++ b/leaf-server/minecraft-patches/features/0266-cache-collision-list.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] cache collision list
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index ea1af07226c9b0d20f0edb5b97786d42a4c4eece..146cd6743bca87c377d170567a27bb26fbd3e20b 100644
+index 8e4a1780ae472f953bd7bb354f306baac3bea46a..5e4bbdb3ca4acd9c69884aea3c17317a62397e16 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1213,6 +1213,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1215,6 +1215,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private final org.dreeam.leaf.world.DespawnMap despawnMap = new org.dreeam.leaf.world.DespawnMap(); // Leaf - optimize despawn
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick

--- a/leaf-server/minecraft-patches/features/0267-fast-bit-radix-sort.patch
+++ b/leaf-server/minecraft-patches/features/0267-fast-bit-radix-sort.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] fast bit radix sort
 Co-authored-by: Taiyou06 <kaandindar21@gmail.com>
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 5e4bbdb3ca4acd9c69884aea3c17317a62397e16..10a8e400981e7d15f3cd8eba7309a48ea5d6062d 100644
+index 30ecebf3d19cf0056d86ec5368978ee1bd98e5fe..b4562a6f8feb9f4b20d7e6cfabc531277f6b4de6 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1216,6 +1216,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1218,6 +1218,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick
      public final org.dreeam.leaf.world.EntityCollisionCache entityCollisionCache = new org.dreeam.leaf.world.EntityCollisionCache(); // Leaf - cache collision list

--- a/leaf-server/minecraft-patches/features/0267-fast-bit-radix-sort.patch
+++ b/leaf-server/minecraft-patches/features/0267-fast-bit-radix-sort.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] fast bit radix sort
 Co-authored-by: Taiyou06 <kaandindar21@gmail.com>
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 146cd6743bca87c377d170567a27bb26fbd3e20b..4b6fa6ef73d42324fec1cfe06b8de880abd8a911 100644
+index 5e4bbdb3ca4acd9c69884aea3c17317a62397e16..10a8e400981e7d15f3cd8eba7309a48ea5d6062d 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1214,6 +1214,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1216,6 +1216,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public final org.dreeam.leaf.world.NatureSpawnChunkMap natureSpawnChunkMap = new org.dreeam.leaf.world.NatureSpawnChunkMap(); // Leaf - optimize mob spawning
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick
      public final org.dreeam.leaf.world.EntityCollisionCache entityCollisionCache = new org.dreeam.leaf.world.EntityCollisionCache(); // Leaf - cache collision list

--- a/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
+++ b/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
@@ -35,10 +35,10 @@ index 9548fea3c629db7829e4b83a18a7749d1f15f6a4..09e727f03fa6731b3325478c43aed3cb
              }
          }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 10a8e400981e7d15f3cd8eba7309a48ea5d6062d..712f8011d216a1d5c0165c649287f5b5edd4f741 100644
+index b4562a6f8feb9f4b20d7e6cfabc531277f6b4de6..0fcf00d09826232d0718094f0375634d803cff3b 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1307,7 +1307,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1309,7 +1309,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                          // We only need to check blocks that are taller than the minimum step height
                          if (org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep > 0 && currentLayers >= org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep) {
                              int layersValueMin = currentLayers - org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep;

--- a/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
+++ b/leaf-server/minecraft-patches/features/0269-Pluto-Expose-Direction-Plane-s-faces.patch
@@ -35,10 +35,10 @@ index 9548fea3c629db7829e4b83a18a7749d1f15f6a4..09e727f03fa6731b3325478c43aed3cb
              }
          }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 4b6fa6ef73d42324fec1cfe06b8de880abd8a911..58724d8f65898f7f532621fbae2cff4eb1796f80 100644
+index 10a8e400981e7d15f3cd8eba7309a48ea5d6062d..712f8011d216a1d5c0165c649287f5b5edd4f741 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1305,7 +1305,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1307,7 +1307,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                          // We only need to check blocks that are taller than the minimum step height
                          if (org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep > 0 && currentLayers >= org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep) {
                              int layersValueMin = currentLayers - org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep;

--- a/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
@@ -1058,10 +1058,10 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
          void sendToTrackingPlayers(Packet<? super ClientGamePacketListener> packet);
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 58724d8f65898f7f532621fbae2cff4eb1796f80..231925545b6543004a0f6164bf73ee7139ad86f6 100644
+index 712f8011d216a1d5c0165c649287f5b5edd4f741..12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -244,6 +244,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -245,6 +245,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
      public boolean hasRidableMoveEvent = false; // Purpur - Ridables
      final List<ServerPlayer> realPlayers; // Leaves - skip
@@ -1069,7 +1069,7 @@ index 58724d8f65898f7f532621fbae2cff4eb1796f80..231925545b6543004a0f6164bf73ee71
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -1129,6 +1130,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1131,6 +1132,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          this.debugSynchronizers.tick(this.server.debugSubscribers());
          profiler.pop();

--- a/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
@@ -152,10 +152,10 @@ index 504fdb2c4000eafae4341ec8b24ce9cb0fcdc274..d600bd9f0b26005966eaba943fc38012
          return ObjectSets.unmodifiable(chunks);
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index afaed2c11ec1058c9f148362c3f657644e8e0e41..22c29547680b9e5882aca54a0342303d30285375 100644
+index 2ff0c52496ebaa714aaa4a643314c8947342b409..4a2cf0b3e9bfb1c129cf724f85405661439a5f66 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1982,6 +1982,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1989,6 +1989,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Leaf end - SparklyPaper - parallel world ticking
          this.isIteratingOverLevels = false; // Paper - Throw exception on world create while being ticked
  
@@ -164,7 +164,7 @@ index afaed2c11ec1058c9f148362c3f657644e8e0e41..22c29547680b9e5882aca54a0342303d
          profiler.popPush("connection");
          this.tickConnection();
          profiler.popPush("players");
-@@ -2074,6 +2076,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2081,6 +2083,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          Map<ResourceKey<Level>, ServerLevel> newLevels = Maps.newLinkedHashMap(oldLevels);
          newLevels.remove(level.dimension());
          if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) level.tickExecutor.shutdown(); // Leaf - SparklyPaper - parallel world ticking (We remove it in here instead of ServerLevel.close() because ServerLevel.close() is never called!)
@@ -173,7 +173,7 @@ index afaed2c11ec1058c9f148362c3f657644e8e0e41..22c29547680b9e5882aca54a0342303d
      }
      // CraftBukkit end
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e15bc33be 100644
+index 094f6af25bcae20d1b56687721485f0cb8b260aa..4829207669d1e0f3e2fc279f79fc3a4e75ed5754 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -1097,6 +1097,12 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -1058,10 +1058,10 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
          void sendToTrackingPlayers(Packet<? super ClientGamePacketListener> packet);
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 712f8011d216a1d5c0165c649287f5b5edd4f741..12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b 100644
+index 0fcf00d09826232d0718094f0375634d803cff3b..2d26ae01136d9cbc4cf3c5ea7c6f63b62da373a2 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -245,6 +245,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -246,6 +246,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
      public boolean hasRidableMoveEvent = false; // Purpur - Ridables
      final List<ServerPlayer> realPlayers; // Leaves - skip
@@ -1069,7 +1069,7 @@ index 712f8011d216a1d5c0165c649287f5b5edd4f741..12a68d76dfd347e77b3c7b1ed580ddc5
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -1131,6 +1132,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1133,6 +1134,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          this.debugSynchronizers.tick(this.server.debugSubscribers());
          profiler.pop();

--- a/leaf-server/minecraft-patches/features/0276-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0276-Rewrite-entity-despawn-time.patch
@@ -120,10 +120,10 @@ index cc02a276e5de57667676e5c2cdb9358f684984ec..53d85b59964fad1ebbd32e939909bb40
  
          private final ChunkEntitySlices[] slices = new ChunkEntitySlices[REGION_SIZE * REGION_SIZE];
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b..17f606bbda49d275274ffb2b760db8dcdb29b1e2 100644
+index 2d26ae01136d9cbc4cf3c5ea7c6f63b62da373a2..a0f982ec0e4861e030f4d8e381167034af9e37f3 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1133,6 +1133,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1135,6 +1135,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.debugSynchronizers.tick(this.server.debugSubscribers());
          profiler.pop();
          this.environmentAttributes().invalidateTickCache();
@@ -131,7 +131,7 @@ index 12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b..17f606bbda49d275274ffb2b760db8dc
          if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled) { this.leaf$asyncTracker.onEntitiesTickEnd(); } // Leaf - Multithreaded tracker
      }
  
-@@ -1651,7 +1652,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1653,7 +1654,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          entity.setOldPosAndRot();
          ProfilerFiller profiler = Profiler.get();
          entity.tickCount++;
@@ -140,7 +140,7 @@ index 12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b..17f606bbda49d275274ffb2b760db8dc
          profiler.push(entity.typeHolder()::getRegisteredName);
          profiler.incrementCounter("tickNonPassenger");
          final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
-@@ -1672,7 +1673,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1674,7 +1675,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
              entity.setOldPosAndRot();
              entity.tickCount++;

--- a/leaf-server/minecraft-patches/features/0276-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0276-Rewrite-entity-despawn-time.patch
@@ -120,10 +120,10 @@ index cc02a276e5de57667676e5c2cdb9358f684984ec..53d85b59964fad1ebbd32e939909bb40
  
          private final ChunkEntitySlices[] slices = new ChunkEntitySlices[REGION_SIZE * REGION_SIZE];
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 231925545b6543004a0f6164bf73ee7139ad86f6..6bad7fa23cfd3be43f6f642ae3eeb02492b0aa2f 100644
+index 12a68d76dfd347e77b3c7b1ed580ddc548f9ac3b..17f606bbda49d275274ffb2b760db8dcdb29b1e2 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1131,6 +1131,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1133,6 +1133,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.debugSynchronizers.tick(this.server.debugSubscribers());
          profiler.pop();
          this.environmentAttributes().invalidateTickCache();
@@ -131,7 +131,7 @@ index 231925545b6543004a0f6164bf73ee7139ad86f6..6bad7fa23cfd3be43f6f642ae3eeb024
          if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled) { this.leaf$asyncTracker.onEntitiesTickEnd(); } // Leaf - Multithreaded tracker
      }
  
-@@ -1649,7 +1650,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1651,7 +1652,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          entity.setOldPosAndRot();
          ProfilerFiller profiler = Profiler.get();
          entity.tickCount++;
@@ -140,7 +140,7 @@ index 231925545b6543004a0f6164bf73ee7139ad86f6..6bad7fa23cfd3be43f6f642ae3eeb024
          profiler.push(entity.typeHolder()::getRegisteredName);
          profiler.incrementCounter("tickNonPassenger");
          final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
-@@ -1670,7 +1671,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1672,7 +1673,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          } else if (entity instanceof Player || this.entityTickList.contains(entity)) {
              entity.setOldPosAndRot();
              entity.tickCount++;

--- a/leaf-server/minecraft-patches/features/0278-Cache-world-border.patch
+++ b/leaf-server/minecraft-patches/features/0278-Cache-world-border.patch
@@ -18,10 +18,10 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6bad7fa23cfd3be43f6f642ae3eeb02492b0aa2f..2fac5a4fd19a5f3d9b832e7611f005b852eec9fa 100644
+index 17f606bbda49d275274ffb2b760db8dcdb29b1e2..457eeed965bc1ee11d05502248bb69e6eb1c04ca 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -245,6 +245,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -246,6 +246,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public boolean hasRidableMoveEvent = false; // Purpur - Ridables
      final List<ServerPlayer> realPlayers; // Leaves - skip
      public final org.dreeam.leaf.async.tracker.AsyncTracker leaf$asyncTracker = new org.dreeam.leaf.async.tracker.AsyncTracker(this); // Leaf - Multithreaded tracker
@@ -29,7 +29,7 @@ index 6bad7fa23cfd3be43f6f642ae3eeb02492b0aa2f..2fac5a4fd19a5f3d9b832e7611f005b8
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2577,8 +2578,14 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2579,8 +2580,14 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      @Override
      public WorldBorder getWorldBorder() {

--- a/leaf-server/minecraft-patches/features/0278-Cache-world-border.patch
+++ b/leaf-server/minecraft-patches/features/0278-Cache-world-border.patch
@@ -18,10 +18,10 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 17f606bbda49d275274ffb2b760db8dcdb29b1e2..457eeed965bc1ee11d05502248bb69e6eb1c04ca 100644
+index a0f982ec0e4861e030f4d8e381167034af9e37f3..0d4c50dd907119d70ec4b510d917c79fcc3ab64f 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -246,6 +246,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -247,6 +247,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public boolean hasRidableMoveEvent = false; // Purpur - Ridables
      final List<ServerPlayer> realPlayers; // Leaves - skip
      public final org.dreeam.leaf.async.tracker.AsyncTracker leaf$asyncTracker = new org.dreeam.leaf.async.tracker.AsyncTracker(this); // Leaf - Multithreaded tracker
@@ -29,7 +29,7 @@ index 17f606bbda49d275274ffb2b760db8dcdb29b1e2..457eeed965bc1ee11d05502248bb69e6
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2579,8 +2580,14 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2581,8 +2582,14 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
      @Override
      public WorldBorder getWorldBorder() {

--- a/leaf-server/minecraft-patches/features/0282-Reduce-optimiseRandomTick-new-BlockPos-instance-crea.patch
+++ b/leaf-server/minecraft-patches/features/0282-Reduce-optimiseRandomTick-new-BlockPos-instance-crea.patch
@@ -27,10 +27,10 @@ index ccc8a5b5a5353e624e86d69617599cc3ac118a9d..480031124848027a006f62a6bbf90c94
  
          // Perform the walk over all directly reachable redstone wire blocks, propagating wire value
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 457eeed965bc1ee11d05502248bb69e6eb1c04ca..84a236ce33a13fc3a7bd393cd8fa45f37c2a4cc5 100644
+index 0d4c50dd907119d70ec4b510d917c79fcc3ab64f..1abf0b8b257b21e3f096bb355b4cbe7b20903947 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1167,6 +1167,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1169,6 +1169,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.players.stream().filter(LivingEntity::isSleeping).collect(Collectors.toList()).forEach(player -> player.stopSleepInBed(false, false));
      }
  
@@ -39,7 +39,7 @@ index 457eeed965bc1ee11d05502248bb69e6eb1c04ca..84a236ce33a13fc3a7bd393cd8fa45f3
      // Paper start - optimise random ticking
      private void optimiseRandomTick(final LevelChunk chunk, final int tickSpeed) {
          final LevelChunkSection[] sections = chunk.getSections();
-@@ -1200,14 +1202,16 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1202,14 +1204,16 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  final int location = (int)tickList.getRaw(index) & 0xFFFF;
                  final BlockState state = states.get(location);
  

--- a/leaf-server/minecraft-patches/features/0282-Reduce-optimiseRandomTick-new-BlockPos-instance-crea.patch
+++ b/leaf-server/minecraft-patches/features/0282-Reduce-optimiseRandomTick-new-BlockPos-instance-crea.patch
@@ -27,10 +27,10 @@ index ccc8a5b5a5353e624e86d69617599cc3ac118a9d..480031124848027a006f62a6bbf90c94
  
          // Perform the walk over all directly reachable redstone wire blocks, propagating wire value
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 2fac5a4fd19a5f3d9b832e7611f005b852eec9fa..d577ddcdeaa0e102f0b09955b77b20fe3854140d 100644
+index 457eeed965bc1ee11d05502248bb69e6eb1c04ca..84a236ce33a13fc3a7bd393cd8fa45f37c2a4cc5 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1165,6 +1165,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1167,6 +1167,8 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          this.players.stream().filter(LivingEntity::isSleeping).collect(Collectors.toList()).forEach(player -> player.stopSleepInBed(false, false));
      }
  
@@ -39,7 +39,7 @@ index 2fac5a4fd19a5f3d9b832e7611f005b852eec9fa..d577ddcdeaa0e102f0b09955b77b20fe
      // Paper start - optimise random ticking
      private void optimiseRandomTick(final LevelChunk chunk, final int tickSpeed) {
          final LevelChunkSection[] sections = chunk.getSections();
-@@ -1198,14 +1200,16 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1200,14 +1202,16 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  final int location = (int)tickList.getRaw(index) & 0xFFFF;
                  final BlockState state = states.get(location);
  

--- a/leaf-server/minecraft-patches/features/0284-Prevent-entities-from-moving-into-weak-loaded-chunks.patch
+++ b/leaf-server/minecraft-patches/features/0284-Prevent-entities-from-moving-into-weak-loaded-chunks.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent entities from moving into weak loaded chunks
 This also should mitigate most cases of memory leaks caused by massive weak loaded projectiles
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d577ddcdeaa0e102f0b09955b77b20fe3854140d..fa2a7e7369afa4396bd5a7a955662e2eb6ddee93 100644
+index 84a236ce33a13fc3a7bd393cd8fa45f37c2a4cc5..c26c8fcb9676ac6b0a30d8bac071ccd75a9b34b3 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -257,8 +257,40 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -258,8 +258,40 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return this.typeKey;
      }
  

--- a/leaf-server/minecraft-patches/features/0284-Prevent-entities-from-moving-into-weak-loaded-chunks.patch
+++ b/leaf-server/minecraft-patches/features/0284-Prevent-entities-from-moving-into-weak-loaded-chunks.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent entities from moving into weak loaded chunks
 This also should mitigate most cases of memory leaks caused by massive weak loaded projectiles
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 84a236ce33a13fc3a7bd393cd8fa45f37c2a4cc5..c26c8fcb9676ac6b0a30d8bac071ccd75a9b34b3 100644
+index 1abf0b8b257b21e3f096bb355b4cbe7b20903947..16e41203ead8398c0020bf6445683d7fbec887b6 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -258,8 +258,40 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -259,8 +259,40 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          return this.typeKey;
      }
  

--- a/leaf-server/minecraft-patches/features/0298-configurable-ice-and-snow-tick-chance.patch
+++ b/leaf-server/minecraft-patches/features/0298-configurable-ice-and-snow-tick-chance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] configurable ice and snow tick chance
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index c26c8fcb9676ac6b0a30d8bac071ccd75a9b34b3..f4a9d432fdf1730b149a1afb310250387839b019 100644
+index 16e41203ead8398c0020bf6445683d7fbec887b6..efcbfc2b8c425f46c6a106b06dbb151d8c8331e5 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1266,9 +1266,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1268,9 +1268,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          ProfilerFiller profiler = Profiler.get();
          profiler.push("iceandsnow");
  

--- a/leaf-server/minecraft-patches/features/0298-configurable-ice-and-snow-tick-chance.patch
+++ b/leaf-server/minecraft-patches/features/0298-configurable-ice-and-snow-tick-chance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] configurable ice and snow tick chance
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index fa2a7e7369afa4396bd5a7a955662e2eb6ddee93..008e2b04434f95879fbe8e85a6f4ab874d087803 100644
+index c26c8fcb9676ac6b0a30d8bac071ccd75a9b34b3..f4a9d432fdf1730b149a1afb310250387839b019 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1264,9 +1264,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1266,9 +1266,10 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          ProfilerFiller profiler = Profiler.get();
          profiler.push("iceandsnow");
  

--- a/leaf-server/minecraft-patches/features/0301-disable-world-data-saving.patch
+++ b/leaf-server/minecraft-patches/features/0301-disable-world-data-saving.patch
@@ -50,10 +50,10 @@ index 9a9a599ef178f851ee5c783631a724013a693586..f950472f371af3581af82c5bcdd7a800
              final CompoundTag save = poi.save();
              poi.setDirty(false);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f4a9d432fdf1730b149a1afb310250387839b019..6afe3432a37dd10e0f1b08498bf894a7cabfea92 100644
+index efcbfc2b8c425f46c6a106b06dbb151d8c8331e5..5a1b281290a1dc54247ad36f925f98113f51a736 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1754,6 +1754,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1756,6 +1756,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper start - Incremental chunk and player saving
      public void saveIncrementally(final boolean doFull) {
@@ -61,7 +61,7 @@ index f4a9d432fdf1730b149a1afb310250387839b019..6afe3432a37dd10e0f1b08498bf894a7
          if (doFull) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld()));
              this.saveLevelData(false);
-@@ -1769,6 +1770,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1771,6 +1772,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave, final boolean close) {
          // Paper end - add close param
          ServerChunkCache chunkSource = this.getChunkSource();

--- a/leaf-server/minecraft-patches/features/0301-disable-world-data-saving.patch
+++ b/leaf-server/minecraft-patches/features/0301-disable-world-data-saving.patch
@@ -50,10 +50,10 @@ index 9a9a599ef178f851ee5c783631a724013a693586..f950472f371af3581af82c5bcdd7a800
              final CompoundTag save = poi.save();
              poi.setDirty(false);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 008e2b04434f95879fbe8e85a6f4ab874d087803..9f498dbcabc9badc337c6039ddc1bd7574709298 100644
+index f4a9d432fdf1730b149a1afb310250387839b019..6afe3432a37dd10e0f1b08498bf894a7cabfea92 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1752,6 +1752,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1754,6 +1754,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      }
      // Paper start - Incremental chunk and player saving
      public void saveIncrementally(final boolean doFull) {
@@ -61,7 +61,7 @@ index 008e2b04434f95879fbe8e85a6f4ab874d087803..9f498dbcabc9badc337c6039ddc1bd75
          if (doFull) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld()));
              this.saveLevelData(false);
-@@ -1767,6 +1768,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1769,6 +1770,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public void save(final @Nullable ProgressListener progressListener, final boolean flush, final boolean noSave, final boolean close) {
          // Paper end - add close param
          ServerChunkCache chunkSource = this.getChunkSource();

--- a/leaf-server/minecraft-patches/features/0303-Leaves-Lithium-Sleeping-Block-Entity.patch
+++ b/leaf-server/minecraft-patches/features/0303-Leaves-Lithium-Sleeping-Block-Entity.patch
@@ -54,10 +54,10 @@ index f2c5a6ce769d8a5fdb4b836eae6a61a4da91cb3f..c6ce0318e27ca49d9bb68f425ab92089
      }
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 9f498dbcabc9badc337c6039ddc1bd7574709298..ecec4d70ddbaa63ab96bbb664beccd3f1c8dea46 100644
+index 6afe3432a37dd10e0f1b08498bf894a7cabfea92..d071e7f891ea723dcff7613615e15c0ac2c75935 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2883,6 +2883,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2885,6 +2885,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (TickingBlockEntity ticker : this.blockEntityTickers) {
              BlockPos blockPos = ticker.getPos();

--- a/leaf-server/minecraft-patches/features/0303-Leaves-Lithium-Sleeping-Block-Entity.patch
+++ b/leaf-server/minecraft-patches/features/0303-Leaves-Lithium-Sleeping-Block-Entity.patch
@@ -54,10 +54,10 @@ index f2c5a6ce769d8a5fdb4b836eae6a61a4da91cb3f..c6ce0318e27ca49d9bb68f425ab92089
      }
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 6afe3432a37dd10e0f1b08498bf894a7cabfea92..d071e7f891ea723dcff7613615e15c0ac2c75935 100644
+index 5a1b281290a1dc54247ad36f925f98113f51a736..d7594d3bc1324dbaedcdf0878bf8f867dff8c057 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2885,6 +2885,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2887,6 +2887,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (TickingBlockEntity ticker : this.blockEntityTickers) {
              BlockPos blockPos = ticker.getPos();

--- a/leaf-server/minecraft-patches/features/0304-fixup-Leaves-Lithium-Sleeping-Block-Entity.patch
+++ b/leaf-server/minecraft-patches/features/0304-fixup-Leaves-Lithium-Sleeping-Block-Entity.patch
@@ -25,10 +25,10 @@ https://github.com/CaffeineMC/lithium/commit/ba08831d0254076cba1e8aba3db6c42f26d
 https://github.com/CaffeineMC/lithium/commit/ba089f52be5b26e6590402211581e05e467a8e2d
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index ecec4d70ddbaa63ab96bbb664beccd3f1c8dea46..d3312527c47df39d91300ff9b915d23bbee027d4 100644
+index d071e7f891ea723dcff7613615e15c0ac2c75935..f025cb628a2fddb56ac0ed7e4a331d841c34c12c 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2883,7 +2883,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2885,7 +2885,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (TickingBlockEntity ticker : this.blockEntityTickers) {
              BlockPos blockPos = ticker.getPos();

--- a/leaf-server/minecraft-patches/features/0304-fixup-Leaves-Lithium-Sleeping-Block-Entity.patch
+++ b/leaf-server/minecraft-patches/features/0304-fixup-Leaves-Lithium-Sleeping-Block-Entity.patch
@@ -25,10 +25,10 @@ https://github.com/CaffeineMC/lithium/commit/ba08831d0254076cba1e8aba3db6c42f26d
 https://github.com/CaffeineMC/lithium/commit/ba089f52be5b26e6590402211581e05e467a8e2d
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d071e7f891ea723dcff7613615e15c0ac2c75935..f025cb628a2fddb56ac0ed7e4a331d841c34c12c 100644
+index d7594d3bc1324dbaedcdf0878bf8f867dff8c057..688654400d99372395753250ccf1c9e0e993e3de 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -2885,7 +2885,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -2887,7 +2887,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
  
          for (TickingBlockEntity ticker : this.blockEntityTickers) {
              BlockPos blockPos = ticker.getPos();

--- a/leaf-server/minecraft-patches/features/0306-Reduce-debug-subscribers-overhead.patch
+++ b/leaf-server/minecraft-patches/features/0306-Reduce-debug-subscribers-overhead.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reduce debug subscribers overhead
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 22c29547680b9e5882aca54a0342303d30285375..3083f7da4bd04db8724f8e457559bef4469d7675 100644
+index 4a2cf0b3e9bfb1c129cf724f85405661439a5f66..29d92f78865c45a0865e885158bec56e18e2de0b 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1989,7 +1989,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1996,7 +1996,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          profiler.popPush("players");
          this.playerList.tick();
          profiler.popPush("debugSubscribers");

--- a/leaf-server/minecraft-patches/features/0308-Add-read-only-mode-for-Linear-v2.patch
+++ b/leaf-server/minecraft-patches/features/0308-Add-read-only-mode-for-Linear-v2.patch
@@ -47,10 +47,10 @@ index 5a8937740f7779f971c2a13ec580eed7bcc26395..98b48a8a6f6372114ee1f71b2c69bff9
  
          try {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index f025cb628a2fddb56ac0ed7e4a331d841c34c12c..4c5eacfec8d060f95b000f24bb41c07392e33eeb 100644
+index 688654400d99372395753250ccf1c9e0e993e3de..9508acbe1bb8f07efb89109ef2fb4055a270d284 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1755,6 +1755,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1757,6 +1757,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper start - Incremental chunk and player saving
      public void saveIncrementally(final boolean doFull) {
          if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this)) return; // Leaf - disable world data saving
@@ -58,7 +58,7 @@ index f025cb628a2fddb56ac0ed7e4a331d841c34c12c..4c5eacfec8d060f95b000f24bb41c073
          if (doFull) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld()));
              this.saveLevelData(false);
-@@ -1771,7 +1772,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1773,7 +1774,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - add close param
          ServerChunkCache chunkSource = this.getChunkSource();
          // Leaf start - disable world data saving

--- a/leaf-server/minecraft-patches/features/0308-Add-read-only-mode-for-Linear-v2.patch
+++ b/leaf-server/minecraft-patches/features/0308-Add-read-only-mode-for-Linear-v2.patch
@@ -47,10 +47,10 @@ index 5a8937740f7779f971c2a13ec580eed7bcc26395..98b48a8a6f6372114ee1f71b2c69bff9
  
          try {
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index d3312527c47df39d91300ff9b915d23bbee027d4..20dbe3ae363cafa853d1f54ae15458348629dd18 100644
+index f025cb628a2fddb56ac0ed7e4a331d841c34c12c..4c5eacfec8d060f95b000f24bb41c07392e33eeb 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1753,6 +1753,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1755,6 +1755,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      // Paper start - Incremental chunk and player saving
      public void saveIncrementally(final boolean doFull) {
          if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this)) return; // Leaf - disable world data saving
@@ -58,7 +58,7 @@ index d3312527c47df39d91300ff9b915d23bbee027d4..20dbe3ae363cafa853d1f54ae1545834
          if (doFull) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld()));
              this.saveLevelData(false);
-@@ -1769,7 +1770,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1771,7 +1772,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
          // Paper end - add close param
          ServerChunkCache chunkSource = this.getChunkSource();
          // Leaf start - disable world data saving

--- a/leaf-server/minecraft-patches/features/0320-optimize-entity-activation.patch
+++ b/leaf-server/minecraft-patches/features/0320-optimize-entity-activation.patch
@@ -164,10 +164,10 @@ index c4194b1921f4741b5452259c0ab87fd94977c7f3..4d5c38c0fb6d18026f84be5eccf87d78
          }
      }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 20dbe3ae363cafa853d1f54ae15458348629dd18..ba589ac63ebba99679e4d20a5f455da85941a44f 100644
+index 4c5eacfec8d060f95b000f24bb41c07392e33eeb..6b5cbe298ee28ec67a61339bd93680f5464ff5f8 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1099,13 +1099,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1101,13 +1101,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  profiler.pop();
              }
  
@@ -183,7 +183,7 @@ index 20dbe3ae363cafa853d1f54ae15458348629dd18..ba589ac63ebba99679e4d20a5f455da8
                          if (!entity.isRemoved()) {
                              if (!tickRateManager.isEntityFrozen(entity)) {
                                  profiler.push("checkDespawn");
-@@ -1256,6 +1256,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1258,6 +1258,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick
      public final org.dreeam.leaf.world.EntityCollisionCache entityCollisionCache = new org.dreeam.leaf.world.EntityCollisionCache(); // Leaf - cache collision list
      public final org.dreeam.leaf.util.FastBitRadixSort fastBitRadixSort = new org.dreeam.leaf.util.FastBitRadixSort(); // Leaf - fast bit radix sort

--- a/leaf-server/minecraft-patches/features/0320-optimize-entity-activation.patch
+++ b/leaf-server/minecraft-patches/features/0320-optimize-entity-activation.patch
@@ -164,10 +164,10 @@ index c4194b1921f4741b5452259c0ab87fd94977c7f3..4d5c38c0fb6d18026f84be5eccf87d78
          }
      }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 4c5eacfec8d060f95b000f24bb41c07392e33eeb..6b5cbe298ee28ec67a61339bd93680f5464ff5f8 100644
+index 9508acbe1bb8f07efb89109ef2fb4055a270d284..875d68d6da06f3aadb38ef676c072cdf977d378a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -1101,13 +1101,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1103,13 +1103,13 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
                  profiler.pop();
              }
  
@@ -183,7 +183,7 @@ index 4c5eacfec8d060f95b000f24bb41c07392e33eeb..6b5cbe298ee28ec67a61339bd93680f5
                          if (!entity.isRemoved()) {
                              if (!tickRateManager.isEntityFrozen(entity)) {
                                  profiler.push("checkDespawn");
-@@ -1258,6 +1258,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+@@ -1260,6 +1260,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
      public final org.dreeam.leaf.world.RandomTickSystem randomTickSystem = new org.dreeam.leaf.world.RandomTickSystem(); // Leaf - optimize random tick
      public final org.dreeam.leaf.world.EntityCollisionCache entityCollisionCache = new org.dreeam.leaf.world.EntityCollisionCache(); // Leaf - cache collision list
      public final org.dreeam.leaf.util.FastBitRadixSort fastBitRadixSort = new org.dreeam.leaf.util.FastBitRadixSort(); // Leaf - fast bit radix sort

--- a/leaf-server/paper-patches/features/0036-Matter-Secure-Seed.patch
+++ b/leaf-server/paper-patches/features/0036-Matter-Secure-Seed.patch
@@ -10,7 +10,7 @@ Co-authored-by: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
 Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index f020f310c4bca49a23de91bea72ccd9941c0b03c..6735a183d9ef6b5e92a5155379085006c9cc653b 100644
+index f020f310c4bca49a23de91bea72ccd9941c0b03c..b665c6b053b7942c3980ea1e5f321a254aab736c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -191,7 +191,14 @@ public class CraftChunk implements Chunk {
@@ -23,7 +23,7 @@ index f020f310c4bca49a23de91bea72ccd9941c0b03c..6735a183d9ef6b5e92a5155379085006
 +            return true;
 +        }
 +        return org.dreeam.leaf.config.modules.misc.SecureSeed.enabled
-+            ? level.getChunk(this.getX(), this.getZ()).isSlimeChunk()
++            ? su.plo.matter.WorldgenCryptoRandom.seedSlimeChunk(this.level, this.getX(), this.getZ()).nextInt(10) == 0
 +            : WorldgenRandom.seedSlimeChunk(this.getX(), this.getZ(), this.getWorld().getSeed(), level.spigotConfig.slimeSeed).nextInt(10) == 0; // Paper;
 +        // Leaf end - Matter - Secure Seed
      }

--- a/leaf-server/paper-patches/features/0036-Matter-Secure-Seed.patch
+++ b/leaf-server/paper-patches/features/0036-Matter-Secure-Seed.patch
@@ -30,7 +30,7 @@ index f020f310c4bca49a23de91bea72ccd9941c0b03c..b665c6b053b7942c3980ea1e5f321a25
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1a2e0c09fb6465a5ac37eab62014f9808284bed2..64e48cd36ae100491e2efd15803b26be16965f46 100644
+index 1a2e0c09fb6465a5ac37eab62014f9808284bed2..c21de3a816eaca0f0fbbfdd46fca71a47a421a70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1254,7 +1254,11 @@ public final class CraftServer implements Server {
@@ -46,3 +46,60 @@ index 1a2e0c09fb6465a5ac37eab62014f9808284bed2..64e48cd36ae100491e2efd15803b26be
  
              String flatGenSettings = creator.generatorSettings();
              if (flatGenSettings.isEmpty()) {
+@@ -1299,7 +1303,13 @@ public final class CraftServer implements Server {
+             throw new IllegalStateException("Missing level stem for world " + name + " using key " + actualDimension);
+         }
+ 
+-        WorldInfo worldInfo = new CraftWorldInfo(loadedWorldData.bukkitName(), CraftNamespacedKey.fromMinecraft(dimensionKey.identifier()), genSettingsFinal.options().seed(), primaryLevelData.enabledFeatures(), creator.environment(), customStem.type().value(), customStem.generator(), registryAccess, loadedWorldData.uuid());
++        // Leaf start - Matter - Secure Seed
++        su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext = su.plo.matter.TerrainCryptoContext.create(
++            genSettingsFinal.options(),
++            dimensionKey
++        );
++        WorldInfo worldInfo = new CraftWorldInfo(loadedWorldData.bukkitName(), CraftNamespacedKey.fromMinecraft(dimensionKey.identifier()), genSettingsFinal.options().seed(), primaryLevelData.enabledFeatures(), creator.environment(), customStem.type().value(), customStem.generator(), registryAccess, terrainCryptoContext, loadedWorldData.uuid());
++        // Leaf end - Matter - Secure Seed
+         if (biomeProvider == null && chunkGenerator != null) {
+             biomeProvider = chunkGenerator.getDefaultBiomeProvider(worldInfo);
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftWorldInfo.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftWorldInfo.java
+index f92a9daafb0527612eee7c2be726c43f61b47cb4..03a2cd34432e47c2ec7bd506415934fa2579421a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/generator/CraftWorldInfo.java
++++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftWorldInfo.java
+@@ -23,6 +23,7 @@ public class CraftWorldInfo implements WorldInfo {
+     private final FeatureFlagSet enabledFeatures;
+     private final ChunkGenerator vanillaChunkGenerator;
+     private final RegistryAccess registryAccess;
++    private final su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext; // Leaf - Matter - Secure Seed
+ 
+     public CraftWorldInfo(
+         String name,
+@@ -35,6 +36,12 @@ public class CraftWorldInfo implements WorldInfo {
+         RegistryAccess registryAccess,
+         UUID uuid
+     ) {
++        // Leaf start - Matter - Secure Seed
++        this(name, dimension, seed, enabledFeatures, environment, dimensionType, vanillaChunkGenerator, registryAccess, null, uuid);
++    }
++
++    public CraftWorldInfo(String name, NamespacedKey dimension, long seed, FeatureFlagSet enabledFeatures, World.Environment environment, DimensionType dimensionType, ChunkGenerator vanillaChunkGenerator, RegistryAccess registryAccess, su.plo.matter.@org.jspecify.annotations.Nullable TerrainCryptoContext terrainCryptoContext, UUID uuid) {
++    // Leaf end - Matter - Secure Seed
+         this.name = name;
+         this.dimension = dimension;
+         this.seed = seed;
+@@ -44,6 +51,7 @@ public class CraftWorldInfo implements WorldInfo {
+         this.maxHeight = dimensionType.minY() + dimensionType.height();
+         this.vanillaChunkGenerator = vanillaChunkGenerator;
+         this.registryAccess = registryAccess;
++        this.terrainCryptoContext = terrainCryptoContext;
+         this.uuid = uuid;
+     }
+ 
+@@ -82,7 +90,7 @@ public class CraftWorldInfo implements WorldInfo {
+         final net.minecraft.world.level.levelgen.RandomState randomState;
+         if (vanillaChunkGenerator instanceof net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator noiseBasedChunkGenerator) {
+             randomState = net.minecraft.world.level.levelgen.RandomState.create(noiseBasedChunkGenerator.generatorSettings().value(),
+-                registryAccess.lookupOrThrow(net.minecraft.core.registries.Registries.NOISE), getSeed());
++                registryAccess.lookupOrThrow(net.minecraft.core.registries.Registries.NOISE), getSeed(), this.terrainCryptoContext);
+         } else {
+             randomState = net.minecraft.world.level.levelgen.RandomState.create(net.minecraft.world.level.levelgen.NoiseGeneratorSettings.dummy(),
+                 registryAccess.lookupOrThrow(net.minecraft.core.registries.Registries.NOISE), getSeed());

--- a/leaf-server/paper-patches/features/0048-Fish-Parallel-World-Ticking-API.patch
+++ b/leaf-server/paper-patches/features/0048-Fish-Parallel-World-Ticking-API.patch
@@ -16,10 +16,10 @@ With this approach only new methods are added into already existing Bukkit API, 
   get standarized.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2cda197a2164a8791ff94fb4408b743875cb3e97..137ee2888d40cf16ba07e980efae436acf7c807e 100644
+index 1c107711efb8fd41f572f57522c905715e780b0f..496424bee1e37ca66bec786e28620db0a3b9fd52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -3135,4 +3135,11 @@ public final class CraftServer implements Server {
+@@ -3141,4 +3141,11 @@ public final class CraftServer implements Server {
          return photographerManager;
      }
      // Leaves end - replay mod api

--- a/leaf-server/paper-patches/features/0057-optimize-mob-spawning.patch
+++ b/leaf-server/paper-patches/features/0057-optimize-mob-spawning.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] optimize mob spawning
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 137ee2888d40cf16ba07e980efae436acf7c807e..bcf8ec090cfd1faed825bfa7bc012e719c7f8da4 100644
+index 496424bee1e37ca66bec786e28620db0a3b9fd52..4c641c75f4c49fd6dcea1088eb7b132788ae78c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -285,7 +285,8 @@ public final class CraftServer implements Server {
@@ -38,7 +38,7 @@ index 137ee2888d40cf16ba07e980efae436acf7c807e..bcf8ec090cfd1faed825bfa7bc012e71
              }
          }
      }
-@@ -2386,7 +2388,7 @@ public final class CraftServer implements Server {
+@@ -2392,7 +2394,7 @@ public final class CraftServer implements Server {
      }
  
      public int getSpawnLimitUnsafe(final SpawnCategory spawnCategory) {

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/SecureSeed.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/SecureSeed.java
@@ -2,6 +2,7 @@ package org.dreeam.leaf.config.modules.misc;
 
 import org.dreeam.leaf.config.ConfigModule;
 import org.dreeam.leaf.config.ConfigCategory;
+import org.dreeam.leaf.config.annotations.Experimental;
 
 public class SecureSeed extends ConfigModule {
 
@@ -10,7 +11,13 @@ public class SecureSeed extends ConfigModule {
     }
 
     public static boolean enabled = false;
+    @Experimental
+    public static boolean terrainEnabled = false;
     private static boolean secureSeedInitialized;
+
+    public static boolean isSecureTerrainEnabled() {
+        return enabled && terrainEnabled;
+    }
 
     @Override
     public void onLoaded() {
@@ -27,5 +34,12 @@ public class SecureSeed extends ConfigModule {
         secureSeedInitialized = true;
 
         enabled = globalConfig.getBoolean(basePath() + ".enabled", enabled);
+        terrainEnabled = globalConfig.getBoolean(basePath() + ".terrain-enabled", terrainEnabled, globalConfig.pickStringRegionBased(
+            """
+                Use an independent 256-bit seed to protect terrain generation.
+                """,
+            """
+                使用独立的 256-bit 种子来保护地形生成.""")
+        );
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/SecureSeed.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/SecureSeed.java
@@ -10,6 +10,7 @@ public class SecureSeed extends ConfigModule {
     }
 
     public static boolean enabled = false;
+    private static boolean secureSeedInitialized;
 
     @Override
     public void onLoaded() {
@@ -18,6 +19,12 @@ public class SecureSeed extends ConfigModule {
                 instead of using 64-bit seed in vanilla, made seed cracker become impossible.""",
             """
                 安全种子开启后, 所有矿物与结构都将使用1024位的种子进行生成, 无法被破解.""");
+
+        if (secureSeedInitialized) {
+            globalConfig.getConfigSection(basePath());
+            return;
+        }
+        secureSeedInitialized = true;
 
         enabled = globalConfig.getBoolean(basePath() + ".enabled", enabled);
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -12,6 +12,8 @@ public final class LeafConstants {
     public static final boolean DISABLE_VANILLA_DEBUG_FEATURE = Boolean.getBoolean("Leaf.disable-vanilla-debug-feature");
     public static final String LINEAR_V2_READ_ONLY_FLAG = "Leaf.linear-v2-read-only";
     public static final boolean LINEAR_V2_READ_ONLY = Boolean.getBoolean(LINEAR_V2_READ_ONLY_FLAG);
+    public static final String DISABLE_SECURE_SEED_INTEGRITY_CHECK_FLAG = "Leaf.disable-secure-seed-integrity-check";
+    public static final boolean DISABLE_SECURE_SEED_INTEGRITY_CHECK = Boolean.getBoolean(DISABLE_SECURE_SEED_INTEGRITY_CHECK_FLAG);
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }

--- a/leaf-server/src/main/java/su/plo/matter/Blake2b.java
+++ b/leaf-server/src/main/java/su/plo/matter/Blake2b.java
@@ -1,0 +1,691 @@
+package su.plo.matter;
+
+import java.util.Objects;
+
+public final class Blake2b {
+    public static final int KEY_BYTES = 32;
+    public static final int OUTPUT_BYTES = 32;
+    private static final int BLOCK_BYTES = 128;
+    private static final int FIXED_16_BYTES = 16;
+    private static final int FIXED_20_BYTES = 20;
+    private static final long PARAMETER_BLOCK = 0x01012020L;
+    private static final long IV_0 = 0x6A09E667F3BCC908L;
+    private static final long IV_1 = 0xBB67AE8584CAA73BL;
+    private static final long IV_2 = 0x3C6EF372FE94F82BL;
+    private static final long IV_3 = 0xA54FF53A5F1D36F1L;
+    private static final long IV_4 = 0x510E527FADE682D1L;
+    private static final long IV_5 = 0x9B05688C2B3E6C1FL;
+    private static final long IV_6 = 0x1F83D9ABFB41BD6BL;
+    private static final long IV_7 = 0x5BE0CD19137E2179L;
+
+    @FunctionalInterface
+    interface Seed128Factory<R> {
+        R create(long seedLo, long seedHi);
+    }
+
+    private Blake2b() {
+    }
+
+    public static PreparedKey prepare(final byte[] key) {
+        return new PreparedKey(key);
+    }
+
+    public static byte[] hash(final byte[] key, final byte[] input) {
+        Objects.requireNonNull(input, "input");
+        byte[] output = new byte[OUTPUT_BYTES];
+        hash(key, null, input, 0, input.length, output, 0);
+        return output;
+    }
+
+    public static void hash(final byte[] key, final byte[] input, final byte[] output) {
+        Objects.requireNonNull(input, "input");
+        hash(key, null, input, 0, input.length, output, 0);
+    }
+
+    public static void hash(final byte[] key, final byte[] input, final int inputOffset, final int inputLength, final byte[] output, final int outputOffset) {
+        hash(key, null, input, inputOffset, inputLength, output, outputOffset);
+    }
+
+    private static void hash(final byte[] key, final PreparedKey preparedKey, final byte[] input, final int inputOffset, final int inputLength, final byte[] output, final int outputOffset) {
+        Objects.requireNonNull(input, "input");
+        Objects.requireNonNull(output, "output");
+        if (preparedKey == null) {
+            Objects.requireNonNull(key, "key");
+            if (key.length != KEY_BYTES) {
+                throw new IllegalArgumentException("BLAKE2b-256 key must be exactly " + KEY_BYTES + " bytes");
+            }
+        }
+        Objects.checkFromIndexSize(inputOffset, inputLength, input.length);
+        Objects.checkFromIndexSize(outputOffset, OUTPUT_BYTES, output.length);
+        if (preparedKey != null && inputLength == 0) {
+            preparedKey.writeEmptyHash(output, outputOffset);
+            return;
+        }
+
+        hashScalar(key, preparedKey, input, inputOffset, inputLength, 0L, 0L, 0L, output, outputOffset, null);
+    }
+
+    private static <R> R hashScalar(final byte[] key, final PreparedKey preparedKey, final byte[] input, final int inputOffset, final int inputLength, final long fixedM0, final long fixedM1, final long fixedM2, final byte[] output, final int outputOffset, final Seed128Factory<R> factory) {
+        final boolean fixedInput = input == null;
+        long h0 = preparedKey == null ? IV_0 ^ PARAMETER_BLOCK : preparedKey.h0;
+        long h1 = preparedKey == null ? IV_1 : preparedKey.h1;
+        long h2 = preparedKey == null ? IV_2 : preparedKey.h2;
+        long h3 = preparedKey == null ? IV_3 : preparedKey.h3;
+        long h4 = preparedKey == null ? IV_4 : preparedKey.h4;
+        long h5 = preparedKey == null ? IV_5 : preparedKey.h5;
+        long h6 = preparedKey == null ? IV_6 : preparedKey.h6;
+        long h7 = preparedKey == null ? IV_7 : preparedKey.h7;
+        long t0 = preparedKey == null ? 0L : BLOCK_BYTES;
+        long t1 = 0L;
+        int offset = inputOffset;
+        int remaining = inputLength;
+        boolean keyBlock = preparedKey == null;
+
+        while (true) {
+            final int blockLength;
+            final boolean last;
+            final long m0;
+            final long m1;
+            final long m2;
+            final long m3;
+            final long m4;
+            final long m5;
+            final long m6;
+            final long m7;
+            final long m8;
+            final long m9;
+            final long m10;
+            final long m11;
+            final long m12;
+            final long m13;
+            final long m14;
+            final long m15;
+
+            if (keyBlock) {
+                blockLength = BLOCK_BYTES;
+                last = remaining == 0;
+                m0 = readLongLittleEndian(key, 0);
+                m1 = readLongLittleEndian(key, 8);
+                m2 = readLongLittleEndian(key, 16);
+                m3 = readLongLittleEndian(key, 24);
+                m4 = 0L;
+                m5 = 0L;
+                m6 = 0L;
+                m7 = 0L;
+                m8 = 0L;
+                m9 = 0L;
+                m10 = 0L;
+                m11 = 0L;
+                m12 = 0L;
+                m13 = 0L;
+                m14 = 0L;
+                m15 = 0L;
+                keyBlock = false;
+            } else if (fixedInput) {
+                blockLength = inputLength;
+                last = true;
+                m0 = fixedM0;
+                m1 = fixedM1;
+                m2 = inputLength == FIXED_20_BYTES ? fixedM2 & 0xFFFFFFFFL : 0L;
+                m3 = 0L;
+                m4 = 0L;
+                m5 = 0L;
+                m6 = 0L;
+                m7 = 0L;
+                m8 = 0L;
+                m9 = 0L;
+                m10 = 0L;
+                m11 = 0L;
+                m12 = 0L;
+                m13 = 0L;
+                m14 = 0L;
+                m15 = 0L;
+                remaining = 0;
+            } else {
+                blockLength = Math.min(remaining, BLOCK_BYTES);
+                last = remaining <= BLOCK_BYTES;
+                m0 = readBlockWord(input, offset, blockLength, 0);
+                m1 = readBlockWord(input, offset, blockLength, 8);
+                m2 = readBlockWord(input, offset, blockLength, 16);
+                m3 = readBlockWord(input, offset, blockLength, 24);
+                m4 = readBlockWord(input, offset, blockLength, 32);
+                m5 = readBlockWord(input, offset, blockLength, 40);
+                m6 = readBlockWord(input, offset, blockLength, 48);
+                m7 = readBlockWord(input, offset, blockLength, 56);
+                m8 = readBlockWord(input, offset, blockLength, 64);
+                m9 = readBlockWord(input, offset, blockLength, 72);
+                m10 = readBlockWord(input, offset, blockLength, 80);
+                m11 = readBlockWord(input, offset, blockLength, 88);
+                m12 = readBlockWord(input, offset, blockLength, 96);
+                m13 = readBlockWord(input, offset, blockLength, 104);
+                m14 = readBlockWord(input, offset, blockLength, 112);
+                m15 = readBlockWord(input, offset, blockLength, 120);
+                offset += blockLength;
+                remaining -= blockLength;
+            }
+
+            long previousT0 = t0;
+            t0 += blockLength;
+            if (Long.compareUnsigned(t0, previousT0) < 0) {
+                t1++;
+            }
+
+            long v0 = h0;
+            long v1 = h1;
+            long v2 = h2;
+            long v3 = h3;
+            long v4 = h4;
+            long v5 = h5;
+            long v6 = h6;
+            long v7 = h7;
+            long v8 = IV_0;
+            long v9 = IV_1;
+            long v10 = IV_2;
+            long v11 = IV_3;
+            long v12 = IV_4 ^ t0;
+            long v13 = IV_5 ^ t1;
+            long v14 = IV_6 ^ (last ? -1L : 0L);
+            long v15 = IV_7;
+
+            for (int round = 0; round < 12; round++) {
+                final long s0;
+                final long s1;
+                final long s2;
+                final long s3;
+                final long s4;
+                final long s5;
+                final long s6;
+                final long s7;
+                final long s8;
+                final long s9;
+                final long s10;
+                final long s11;
+                final long s12;
+                final long s13;
+                final long s14;
+                final long s15;
+
+                switch (round) {
+                    case 0, 10 -> {
+                        s0 = m0;
+                        s1 = m1;
+                        s2 = m2;
+                        s3 = m3;
+                        s4 = m4;
+                        s5 = m5;
+                        s6 = m6;
+                        s7 = m7;
+                        s8 = m8;
+                        s9 = m9;
+                        s10 = m10;
+                        s11 = m11;
+                        s12 = m12;
+                        s13 = m13;
+                        s14 = m14;
+                        s15 = m15;
+                    }
+                    case 1, 11 -> {
+                        s0 = m14;
+                        s1 = m10;
+                        s2 = m4;
+                        s3 = m8;
+                        s4 = m9;
+                        s5 = m15;
+                        s6 = m13;
+                        s7 = m6;
+                        s8 = m1;
+                        s9 = m12;
+                        s10 = m0;
+                        s11 = m2;
+                        s12 = m11;
+                        s13 = m7;
+                        s14 = m5;
+                        s15 = m3;
+                    }
+                    case 2 -> {
+                        s0 = m11;
+                        s1 = m8;
+                        s2 = m12;
+                        s3 = m0;
+                        s4 = m5;
+                        s5 = m2;
+                        s6 = m15;
+                        s7 = m13;
+                        s8 = m10;
+                        s9 = m14;
+                        s10 = m3;
+                        s11 = m6;
+                        s12 = m7;
+                        s13 = m1;
+                        s14 = m9;
+                        s15 = m4;
+                    }
+                    case 3 -> {
+                        s0 = m7;
+                        s1 = m9;
+                        s2 = m3;
+                        s3 = m1;
+                        s4 = m13;
+                        s5 = m12;
+                        s6 = m11;
+                        s7 = m14;
+                        s8 = m2;
+                        s9 = m6;
+                        s10 = m5;
+                        s11 = m10;
+                        s12 = m4;
+                        s13 = m0;
+                        s14 = m15;
+                        s15 = m8;
+                    }
+                    case 4 -> {
+                        s0 = m9;
+                        s1 = m0;
+                        s2 = m5;
+                        s3 = m7;
+                        s4 = m2;
+                        s5 = m4;
+                        s6 = m10;
+                        s7 = m15;
+                        s8 = m14;
+                        s9 = m1;
+                        s10 = m11;
+                        s11 = m12;
+                        s12 = m6;
+                        s13 = m8;
+                        s14 = m3;
+                        s15 = m13;
+                    }
+                    case 5 -> {
+                        s0 = m2;
+                        s1 = m12;
+                        s2 = m6;
+                        s3 = m10;
+                        s4 = m0;
+                        s5 = m11;
+                        s6 = m8;
+                        s7 = m3;
+                        s8 = m4;
+                        s9 = m13;
+                        s10 = m7;
+                        s11 = m5;
+                        s12 = m15;
+                        s13 = m14;
+                        s14 = m1;
+                        s15 = m9;
+                    }
+                    case 6 -> {
+                        s0 = m12;
+                        s1 = m5;
+                        s2 = m1;
+                        s3 = m15;
+                        s4 = m14;
+                        s5 = m13;
+                        s6 = m4;
+                        s7 = m10;
+                        s8 = m0;
+                        s9 = m7;
+                        s10 = m6;
+                        s11 = m3;
+                        s12 = m9;
+                        s13 = m2;
+                        s14 = m8;
+                        s15 = m11;
+                    }
+                    case 7 -> {
+                        s0 = m13;
+                        s1 = m11;
+                        s2 = m7;
+                        s3 = m14;
+                        s4 = m12;
+                        s5 = m1;
+                        s6 = m3;
+                        s7 = m9;
+                        s8 = m5;
+                        s9 = m0;
+                        s10 = m15;
+                        s11 = m4;
+                        s12 = m8;
+                        s13 = m6;
+                        s14 = m2;
+                        s15 = m10;
+                    }
+                    case 8 -> {
+                        s0 = m6;
+                        s1 = m15;
+                        s2 = m14;
+                        s3 = m9;
+                        s4 = m11;
+                        s5 = m3;
+                        s6 = m0;
+                        s7 = m8;
+                        s8 = m12;
+                        s9 = m2;
+                        s10 = m13;
+                        s11 = m7;
+                        s12 = m1;
+                        s13 = m4;
+                        s14 = m10;
+                        s15 = m5;
+                    }
+                    case 9 -> {
+                        s0 = m10;
+                        s1 = m2;
+                        s2 = m8;
+                        s3 = m4;
+                        s4 = m7;
+                        s5 = m6;
+                        s6 = m1;
+                        s7 = m5;
+                        s8 = m15;
+                        s9 = m11;
+                        s10 = m9;
+                        s11 = m14;
+                        s12 = m3;
+                        s13 = m12;
+                        s14 = m13;
+                        s15 = m0;
+                    }
+                    default -> throw new AssertionError("Invalid BLAKE2b round: " + round);
+                }
+
+                v0 = v0 + v4 + s0;
+                v12 = Long.rotateRight(v12 ^ v0, 32);
+                v8 += v12;
+                v4 = Long.rotateRight(v4 ^ v8, 24);
+                v0 = v0 + v4 + s1;
+                v12 = Long.rotateRight(v12 ^ v0, 16);
+                v8 += v12;
+                v4 = Long.rotateRight(v4 ^ v8, 63);
+
+                v1 = v1 + v5 + s2;
+                v13 = Long.rotateRight(v13 ^ v1, 32);
+                v9 += v13;
+                v5 = Long.rotateRight(v5 ^ v9, 24);
+                v1 = v1 + v5 + s3;
+                v13 = Long.rotateRight(v13 ^ v1, 16);
+                v9 += v13;
+                v5 = Long.rotateRight(v5 ^ v9, 63);
+
+                v2 = v2 + v6 + s4;
+                v14 = Long.rotateRight(v14 ^ v2, 32);
+                v10 += v14;
+                v6 = Long.rotateRight(v6 ^ v10, 24);
+                v2 = v2 + v6 + s5;
+                v14 = Long.rotateRight(v14 ^ v2, 16);
+                v10 += v14;
+                v6 = Long.rotateRight(v6 ^ v10, 63);
+
+                v3 = v3 + v7 + s6;
+                v15 = Long.rotateRight(v15 ^ v3, 32);
+                v11 += v15;
+                v7 = Long.rotateRight(v7 ^ v11, 24);
+                v3 = v3 + v7 + s7;
+                v15 = Long.rotateRight(v15 ^ v3, 16);
+                v11 += v15;
+                v7 = Long.rotateRight(v7 ^ v11, 63);
+
+                v0 = v0 + v5 + s8;
+                v15 = Long.rotateRight(v15 ^ v0, 32);
+                v10 += v15;
+                v5 = Long.rotateRight(v5 ^ v10, 24);
+                v0 = v0 + v5 + s9;
+                v15 = Long.rotateRight(v15 ^ v0, 16);
+                v10 += v15;
+                v5 = Long.rotateRight(v5 ^ v10, 63);
+
+                v1 = v1 + v6 + s10;
+                v12 = Long.rotateRight(v12 ^ v1, 32);
+                v11 += v12;
+                v6 = Long.rotateRight(v6 ^ v11, 24);
+                v1 = v1 + v6 + s11;
+                v12 = Long.rotateRight(v12 ^ v1, 16);
+                v11 += v12;
+                v6 = Long.rotateRight(v6 ^ v11, 63);
+
+                v2 = v2 + v7 + s12;
+                v13 = Long.rotateRight(v13 ^ v2, 32);
+                v8 += v13;
+                v7 = Long.rotateRight(v7 ^ v8, 24);
+                v2 = v2 + v7 + s13;
+                v13 = Long.rotateRight(v13 ^ v2, 16);
+                v8 += v13;
+                v7 = Long.rotateRight(v7 ^ v8, 63);
+
+                v3 = v3 + v4 + s14;
+                v14 = Long.rotateRight(v14 ^ v3, 32);
+                v9 += v14;
+                v4 = Long.rotateRight(v4 ^ v9, 24);
+                v3 = v3 + v4 + s15;
+                v14 = Long.rotateRight(v14 ^ v3, 16);
+                v9 += v14;
+                v4 = Long.rotateRight(v4 ^ v9, 63);
+            }
+
+            h0 ^= v0 ^ v8;
+            h1 ^= v1 ^ v9;
+            h2 ^= v2 ^ v10;
+            h3 ^= v3 ^ v11;
+            h4 ^= v4 ^ v12;
+            h5 ^= v5 ^ v13;
+            h6 ^= v6 ^ v14;
+            h7 ^= v7 ^ v15;
+
+            if (last) {
+                break;
+            }
+        }
+
+        if (output != null) {
+            writeLongLittleEndian(output, outputOffset, h0);
+            writeLongLittleEndian(output, outputOffset + 8, h1);
+            writeLongLittleEndian(output, outputOffset + 16, h2);
+            writeLongLittleEndian(output, outputOffset + 24, h3);
+            return null;
+        }
+        if ((h0 | h1) != 0L) {
+            return factory.create(h0, h1);
+        }
+        if ((h2 | h3) != 0L) {
+            return factory.create(h2, h3);
+        }
+        return null;
+    }
+
+    public static final class PreparedKey {
+        private final long h0;
+        private final long h1;
+        private final long h2;
+        private final long h3;
+        private final long h4;
+        private final long h5;
+        private final long h6;
+        private final long h7;
+        private final long emptyH0;
+        private final long emptyH1;
+        private final long emptyH2;
+        private final long emptyH3;
+
+        private PreparedKey(final byte[] key) {
+            Objects.requireNonNull(key, "key");
+            if (key.length != KEY_BYTES) {
+                throw new IllegalArgumentException("BLAKE2b-256 key must be exactly " + KEY_BYTES + " bytes");
+            }
+
+            long[] message = new long[16];
+            message[0] = readLongLittleEndian(key, 0);
+            message[1] = readLongLittleEndian(key, 8);
+            message[2] = readLongLittleEndian(key, 16);
+            message[3] = readLongLittleEndian(key, 24);
+            long[] chain = new long[8];
+            long[] state = new long[16];
+
+            initializeChain(chain);
+            compress(chain, message, state, BLOCK_BYTES, 0L, false);
+            this.h0 = chain[0];
+            this.h1 = chain[1];
+            this.h2 = chain[2];
+            this.h3 = chain[3];
+            this.h4 = chain[4];
+            this.h5 = chain[5];
+            this.h6 = chain[6];
+            this.h7 = chain[7];
+
+            initializeChain(chain);
+            compress(chain, message, state, BLOCK_BYTES, 0L, true);
+            this.emptyH0 = chain[0];
+            this.emptyH1 = chain[1];
+            this.emptyH2 = chain[2];
+            this.emptyH3 = chain[3];
+
+        }
+
+        public byte[] hash(final byte[] input) {
+            Objects.requireNonNull(input, "input");
+            byte[] output = new byte[OUTPUT_BYTES];
+            Blake2b.hash(null, this, input, 0, input.length, output, 0);
+            return output;
+        }
+
+        public void hash(final byte[] input, final byte[] output) {
+            Objects.requireNonNull(input, "input");
+            Blake2b.hash(null, this, input, 0, input.length, output, 0);
+        }
+
+        public void hash(final byte[] input, final int inputOffset, final int inputLength, final byte[] output, final int outputOffset) {
+            Blake2b.hash(null, this, input, inputOffset, inputLength, output, outputOffset);
+        }
+
+        void hashFixed16(final long m0, final long m1, final byte[] output, final int outputOffset) {
+            Objects.requireNonNull(output, "output");
+            Objects.checkFromIndexSize(outputOffset, OUTPUT_BYTES, output.length);
+            Blake2b.hashScalar(null, this, null, 0, FIXED_16_BYTES, m0, m1, 0L, output, outputOffset, null);
+        }
+
+        void hashFixed20(final long m0, final long m1, final long m2, final byte[] output, final int outputOffset) {
+            Objects.requireNonNull(output, "output");
+            Objects.checkFromIndexSize(outputOffset, OUTPUT_BYTES, output.length);
+            Blake2b.hashScalar(null, this, null, 0, FIXED_20_BYTES, m0, m1, m2, output, outputOffset, null);
+        }
+
+        <R> R hashFixed16(final long m0, final long m1, final Seed128Factory<R> factory) {
+            Objects.requireNonNull(factory, "factory");
+            return Blake2b.hashScalar(null, this, null, 0, FIXED_16_BYTES, m0, m1, 0L, null, 0, factory);
+        }
+
+        <R> R hashFixed20(final long m0, final long m1, final long m2, final Seed128Factory<R> factory) {
+            Objects.requireNonNull(factory, "factory");
+            return Blake2b.hashScalar(null, this, null, 0, FIXED_20_BYTES, m0, m1, m2, null, 0, factory);
+        }
+
+        private void writeEmptyHash(final byte[] output, final int outputOffset) {
+            writeLongLittleEndian(output, outputOffset, this.emptyH0);
+            writeLongLittleEndian(output, outputOffset + 8, this.emptyH1);
+            writeLongLittleEndian(output, outputOffset + 16, this.emptyH2);
+            writeLongLittleEndian(output, outputOffset + 24, this.emptyH3);
+        }
+    }
+
+    private static void initializeChain(final long[] chain) {
+        chain[0] = IV_0 ^ PARAMETER_BLOCK;
+        chain[1] = IV_1;
+        chain[2] = IV_2;
+        chain[3] = IV_3;
+        chain[4] = IV_4;
+        chain[5] = IV_5;
+        chain[6] = IV_6;
+        chain[7] = IV_7;
+    }
+
+    private static void compress(final long[] chain, final long[] message, final long[] state, final long t0, final long t1, final boolean last) {
+        System.arraycopy(chain, 0, state, 0, chain.length);
+        state[8] = IV_0;
+        state[9] = IV_1;
+        state[10] = IV_2;
+        state[11] = IV_3;
+        state[12] = IV_4 ^ t0;
+        state[13] = IV_5 ^ t1;
+        state[14] = IV_6 ^ (last ? -1L : 0L);
+        state[15] = IV_7;
+
+        for (int round = 0; round < 12; round++) {
+            switch (round) {
+                case 0, 10 -> round(message, state, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+                case 1, 11 -> round(message, state, 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3);
+                case 2 -> round(message, state, 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4);
+                case 3 -> round(message, state, 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8);
+                case 4 -> round(message, state, 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13);
+                case 5 -> round(message, state, 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9);
+                case 6 -> round(message, state, 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11);
+                case 7 -> round(message, state, 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10);
+                case 8 -> round(message, state, 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5);
+                case 9 -> round(message, state, 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0);
+                default -> throw new AssertionError("Invalid BLAKE2b round: " + round);
+            }
+        }
+
+        for (int i = 0; i < chain.length; i++) {
+            chain[i] ^= state[i] ^ state[i + 8];
+        }
+    }
+
+    private static void round(final long[] message, final long[] state, final int s0, final int s1, final int s2, final int s3, final int s4, final int s5, final int s6, final int s7, final int s8, final int s9, final int s10, final int s11, final int s12, final int s13, final int s14, final int s15) {
+        mix(message[s0], message[s1], 0, 4, 8, 12, state);
+        mix(message[s2], message[s3], 1, 5, 9, 13, state);
+        mix(message[s4], message[s5], 2, 6, 10, 14, state);
+        mix(message[s6], message[s7], 3, 7, 11, 15, state);
+        mix(message[s8], message[s9], 0, 5, 10, 15, state);
+        mix(message[s10], message[s11], 1, 6, 11, 12, state);
+        mix(message[s12], message[s13], 2, 7, 8, 13, state);
+        mix(message[s14], message[s15], 3, 4, 9, 14, state);
+    }
+
+    private static void mix(final long x, final long y, final int a, final int b, final int c, final int d, final long[] state) {
+        state[a] = state[a] + state[b] + x;
+        state[d] = Long.rotateRight(state[d] ^ state[a], 32);
+        state[c] += state[d];
+        state[b] = Long.rotateRight(state[b] ^ state[c], 24);
+        state[a] = state[a] + state[b] + y;
+        state[d] = Long.rotateRight(state[d] ^ state[a], 16);
+        state[c] += state[d];
+        state[b] = Long.rotateRight(state[b] ^ state[c], 63);
+    }
+
+    private static long readBlockWord(final byte[] input, final int blockOffset, final int blockLength, final int wordOffset) {
+        int available = blockLength - wordOffset;
+        if (available <= 0) {
+            return 0L;
+        }
+        if (available >= Long.BYTES) {
+            return readLongLittleEndian(input, blockOffset + wordOffset);
+        }
+        int length = Math.min(available, Long.BYTES);
+        long value = 0L;
+        for (int i = 0; i < length; i++) {
+            value |= (input[blockOffset + wordOffset + i] & 0xFFL) << i * Byte.SIZE;
+        }
+        return value;
+    }
+
+    private static long readLongLittleEndian(final byte[] input, final int offset) {
+        return (input[offset] & 0xFFL)
+            | (input[offset + 1] & 0xFFL) << 8
+            | (input[offset + 2] & 0xFFL) << 16
+            | (input[offset + 3] & 0xFFL) << 24
+            | (input[offset + 4] & 0xFFL) << 32
+            | (input[offset + 5] & 0xFFL) << 40
+            | (input[offset + 6] & 0xFFL) << 48
+            | (input[offset + 7] & 0xFFL) << 56;
+    }
+
+    private static void writeLongLittleEndian(final byte[] output, final int offset, final long value) {
+        output[offset] = (byte) value;
+        output[offset + 1] = (byte) (value >>> 8);
+        output[offset + 2] = (byte) (value >>> 16);
+        output[offset + 3] = (byte) (value >>> 24);
+        output[offset + 4] = (byte) (value >>> 32);
+        output[offset + 5] = (byte) (value >>> 40);
+        output[offset + 6] = (byte) (value >>> 48);
+        output[offset + 7] = (byte) (value >>> 56);
+    }
+}

--- a/leaf-server/src/main/java/su/plo/matter/Blake2bRandomSource.java
+++ b/leaf-server/src/main/java/su/plo/matter/Blake2bRandomSource.java
@@ -1,31 +1,24 @@
 package su.plo.matter;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import javax.crypto.Mac;
+import java.util.Objects;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.levelgen.BitRandomSource;
 import net.minecraft.world.level.levelgen.MarsagliaPolarGaussian;
 import net.minecraft.world.level.levelgen.PositionalRandomFactory;
 
-final class HmacSha256RandomSource implements BitRandomSource {
-    private static final int BLOCK_BITS = 256;
-    private final byte[] baseKey;
-    private byte[] streamKey;
-    private final byte[] block = new byte[TerrainCrypto.MASTER_SEED_BYTES];
+final class Blake2bRandomSource implements BitRandomSource {
+    private static final int BLOCK_BITS = Blake2b.OUTPUT_BYTES * Byte.SIZE;
+    private final Blake2b.PreparedKey baseKey;
+    private Blake2b.PreparedKey streamKey;
+    private final byte[] block = new byte[Blake2b.OUTPUT_BYTES];
     private final MarsagliaPolarGaussian gaussianSource = new MarsagliaPolarGaussian(this);
-    private Mac blockMac;
     private long counter;
     private boolean exhausted;
     private int bitIndex = BLOCK_BITS;
 
-    HmacSha256RandomSource(final byte[] key) {
-        if (key.length != TerrainCrypto.MASTER_SEED_BYTES) {
-            throw new IllegalArgumentException("HMAC random source key must be exactly " + TerrainCrypto.MASTER_SEED_BYTES + " bytes");
-        }
-        this.baseKey = key.clone();
-        this.streamKey = key.clone();
-        this.blockMac = TerrainHashing.createMac(this.streamKey);
+    Blake2bRandomSource(final Blake2b.PreparedKey key) {
+        this.baseKey = Objects.requireNonNull(key, "key");
+        this.streamKey = key;
     }
 
     @Override
@@ -52,22 +45,19 @@ final class HmacSha256RandomSource implements BitRandomSource {
 
     @Override
     public RandomSource fork() {
-        return new HmacSha256RandomSource(
-            TerrainHashing.derive(this.streamKey, TerrainHashing.FORK, this.consumeMasterSeed())
-        );
+        byte[] forkSeed = this.consumeMasterSeed();
+        return new Blake2bRandomSource(TerrainHashing.derivePrepared(this.streamKey, TerrainHashing.FORK, forkSeed));
     }
 
     @Override
     public PositionalRandomFactory forkPositional() {
-        return new HmacPositionalRandomFactory(
-            TerrainHashing.derive(this.streamKey, TerrainHashing.POSITIONAL_FORK, this.consumeMasterSeed())
-        );
+        byte[] forkSeed = this.consumeMasterSeed();
+        return new Blake2bPositionalRandomFactory(TerrainHashing.derivePrepared(this.streamKey, TerrainHashing.POSITIONAL_FORK, forkSeed));
     }
 
     @Override
     public void setSeed(final long seed) {
-        this.streamKey = TerrainHashing.derive(this.baseKey, TerrainHashing.SET_SEED, TerrainHashing.longContext(seed));
-        this.blockMac = TerrainHashing.createMac(this.streamKey);
+        this.streamKey = TerrainHashing.derivePreparedLong(this.baseKey, TerrainHashing.SET_SEED, seed);
         this.counter = 0L;
         this.exhausted = false;
         this.bitIndex = BLOCK_BITS;
@@ -116,7 +106,7 @@ final class HmacSha256RandomSource implements BitRandomSource {
             return;
         }
         if (this.exhausted) {
-            throw new IllegalStateException("HMAC random source counter exhausted");
+            throw new IllegalStateException("BLAKE2b random source counter exhausted");
         }
 
         long blockCounter = this.counter;
@@ -125,7 +115,7 @@ final class HmacSha256RandomSource implements BitRandomSource {
         } else {
             this.counter = blockCounter + 1L;
         }
-        TerrainHashing.deriveBlock(this.blockMac, blockCounter, this.block);
+        TerrainHashing.deriveBlock(this.streamKey, blockCounter, this.block);
         this.bitIndex = 0;
     }
 
@@ -134,13 +124,13 @@ final class HmacSha256RandomSource implements BitRandomSource {
             return;
         }
         if (this.exhausted) {
-            throw new IllegalStateException("HMAC random source counter exhausted");
+            throw new IllegalStateException("BLAKE2b random source counter exhausted");
         }
 
         long nextCounter = this.counter + blocks;
         if (Long.compareUnsigned(nextCounter, this.counter) < 0) {
             if (nextCounter != 0L) {
-                throw new IllegalStateException("HMAC random source counter exhausted");
+                throw new IllegalStateException("BLAKE2b random source counter exhausted");
             }
             this.exhausted = true;
         }
@@ -148,44 +138,42 @@ final class HmacSha256RandomSource implements BitRandomSource {
     }
 
     private byte[] consumeMasterSeed() {
-        ByteBuffer buffer = ByteBuffer.allocate(TerrainCrypto.MASTER_SEED_BYTES).order(ByteOrder.BIG_ENDIAN);
-        for (int i = 0; i < TerrainCrypto.MASTER_SEED_BYTES / Integer.BYTES; i++) {
-            buffer.putInt(this.next(Integer.SIZE));
+        byte[] seed = new byte[Blake2b.OUTPUT_BYTES];
+        for (int i = 0; i < seed.length; i += Integer.BYTES) {
+            int value = this.next(Integer.SIZE);
+            seed[i] = (byte) (value >>> 24);
+            seed[i + 1] = (byte) (value >>> 16);
+            seed[i + 2] = (byte) (value >>> 8);
+            seed[i + 3] = (byte) value;
         }
-        return buffer.array();
+        return seed;
     }
 
-    private static final class HmacPositionalRandomFactory implements PositionalRandomFactory {
-        private final byte[] key;
+    private static final class Blake2bPositionalRandomFactory implements PositionalRandomFactory {
+        private final Blake2b.PreparedKey key;
 
-        private HmacPositionalRandomFactory(final byte[] key) {
-            this.key = key.clone();
+        private Blake2bPositionalRandomFactory(final Blake2b.PreparedKey key) {
+            this.key = key;
         }
 
         @Override
         public RandomSource at(final int x, final int y, final int z) {
-            return new HmacSha256RandomSource(
-                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_AT, TerrainHashing.positionContext(x, y, z))
-            );
+            return new Blake2bRandomSource(TerrainHashing.derivePreparedPosition(this.key, TerrainHashing.POSITIONAL_AT, x, y, z));
         }
 
         @Override
         public RandomSource fromHashOf(final String name) {
-            return new HmacSha256RandomSource(
-                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_HASH, TerrainHashing.stringContext(name))
-            );
+            return new Blake2bRandomSource(TerrainHashing.derivePrepared(this.key, TerrainHashing.POSITIONAL_HASH, TerrainHashing.stringToBytes(name)));
         }
 
         @Override
         public RandomSource fromSeed(final long seed) {
-            return new HmacSha256RandomSource(
-                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_SEED, TerrainHashing.longContext(seed))
-            );
+            return new Blake2bRandomSource(TerrainHashing.derivePreparedLong(this.key, TerrainHashing.POSITIONAL_SEED, seed));
         }
 
         @Override
         public void parityConfigString(final StringBuilder sb) {
-            sb.append("HmacSha256PositionalRandomFactory");
+            sb.append("Blake2bPositionalRandomFactory");
         }
     }
 }

--- a/leaf-server/src/main/java/su/plo/matter/ChaCha12.java
+++ b/leaf-server/src/main/java/su/plo/matter/ChaCha12.java
@@ -1,0 +1,192 @@
+package su.plo.matter;
+
+import java.util.Objects;
+
+public final class ChaCha12 {
+    public static final int KEY_BYTES = 32;
+    private static final int CONSTANT_0 = 0x61707865;
+    private static final int CONSTANT_1 = 0x3320646E;
+    private static final int CONSTANT_2 = 0x79622D32;
+    private static final int CONSTANT_3 = 0x6B206574;
+    private static final int DOUBLE_ROUNDS = 6;
+
+    @FunctionalInterface
+    interface Seed128Factory<R> {
+        R create(long seedLo, long seedHi);
+    }
+
+    private ChaCha12() {
+    }
+
+    public static PreparedKey prepare(final byte[] key) {
+        return new PreparedKey(key);
+    }
+
+    public static final class PreparedKey {
+        private final int key0;
+        private final int key1;
+        private final int key2;
+        private final int key3;
+        private final int key4;
+        private final int key5;
+        private final int key6;
+        private final int key7;
+
+        private PreparedKey(final byte[] key) {
+            Objects.requireNonNull(key, "key");
+            if (key.length != KEY_BYTES) {
+                throw new IllegalArgumentException("ChaCha12 key must be exactly " + KEY_BYTES + " bytes");
+            }
+
+            this.key0 = readIntLittleEndian(key, 0);
+            this.key1 = readIntLittleEndian(key, 4);
+            this.key2 = readIntLittleEndian(key, 8);
+            this.key3 = readIntLittleEndian(key, 12);
+            this.key4 = readIntLittleEndian(key, 16);
+            this.key5 = readIntLittleEndian(key, 20);
+            this.key6 = readIntLittleEndian(key, 24);
+            this.key7 = readIntLittleEndian(key, 28);
+        }
+
+        <R> R derive(final int nonce0, final int nonce1, final int nonce2, final Seed128Factory<R> factory) {
+            Objects.requireNonNull(factory, "factory");
+            int counter = 0;
+            while (true) {
+                R result = this.block(counter, nonce0, nonce1, nonce2, factory);
+                if (result != null) {
+                    return result;
+                }
+                if (counter == -1) {
+                    throw new IllegalStateException("Unable to derive a non-zero ChaCha12 seed");
+                }
+                counter++;
+            }
+        }
+
+        private <R> R block(final int counter, final int nonce0, final int nonce1, final int nonce2, final Seed128Factory<R> factory) {
+            int x0 = CONSTANT_0;
+            int x1 = CONSTANT_1;
+            int x2 = CONSTANT_2;
+            int x3 = CONSTANT_3;
+            int x4 = this.key0;
+            int x5 = this.key1;
+            int x6 = this.key2;
+            int x7 = this.key3;
+            int x8 = this.key4;
+            int x9 = this.key5;
+            int x10 = this.key6;
+            int x11 = this.key7;
+            int x12 = counter;
+            int x13 = nonce0;
+            int x14 = nonce1;
+            int x15 = nonce2;
+
+            for (int round = 0; round < DOUBLE_ROUNDS; round++) {
+                x0 += x4;
+                x12 = Integer.rotateLeft(x12 ^ x0, 16);
+                x8 += x12;
+                x4 = Integer.rotateLeft(x4 ^ x8, 12);
+                x0 += x4;
+                x12 = Integer.rotateLeft(x12 ^ x0, 8);
+                x8 += x12;
+                x4 = Integer.rotateLeft(x4 ^ x8, 7);
+
+                x1 += x5;
+                x13 = Integer.rotateLeft(x13 ^ x1, 16);
+                x9 += x13;
+                x5 = Integer.rotateLeft(x5 ^ x9, 12);
+                x1 += x5;
+                x13 = Integer.rotateLeft(x13 ^ x1, 8);
+                x9 += x13;
+                x5 = Integer.rotateLeft(x5 ^ x9, 7);
+
+                x2 += x6;
+                x14 = Integer.rotateLeft(x14 ^ x2, 16);
+                x10 += x14;
+                x6 = Integer.rotateLeft(x6 ^ x10, 12);
+                x2 += x6;
+                x14 = Integer.rotateLeft(x14 ^ x2, 8);
+                x10 += x14;
+                x6 = Integer.rotateLeft(x6 ^ x10, 7);
+
+                x3 += x7;
+                x15 = Integer.rotateLeft(x15 ^ x3, 16);
+                x11 += x15;
+                x7 = Integer.rotateLeft(x7 ^ x11, 12);
+                x3 += x7;
+                x15 = Integer.rotateLeft(x15 ^ x3, 8);
+                x11 += x15;
+                x7 = Integer.rotateLeft(x7 ^ x11, 7);
+
+                x0 += x5;
+                x15 = Integer.rotateLeft(x15 ^ x0, 16);
+                x10 += x15;
+                x5 = Integer.rotateLeft(x5 ^ x10, 12);
+                x0 += x5;
+                x15 = Integer.rotateLeft(x15 ^ x0, 8);
+                x10 += x15;
+                x5 = Integer.rotateLeft(x5 ^ x10, 7);
+
+                x1 += x6;
+                x12 = Integer.rotateLeft(x12 ^ x1, 16);
+                x11 += x12;
+                x6 = Integer.rotateLeft(x6 ^ x11, 12);
+                x1 += x6;
+                x12 = Integer.rotateLeft(x12 ^ x1, 8);
+                x11 += x12;
+                x6 = Integer.rotateLeft(x6 ^ x11, 7);
+
+                x2 += x7;
+                x13 = Integer.rotateLeft(x13 ^ x2, 16);
+                x8 += x13;
+                x7 = Integer.rotateLeft(x7 ^ x8, 12);
+                x2 += x7;
+                x13 = Integer.rotateLeft(x13 ^ x2, 8);
+                x8 += x13;
+                x7 = Integer.rotateLeft(x7 ^ x8, 7);
+
+                x3 += x4;
+                x14 = Integer.rotateLeft(x14 ^ x3, 16);
+                x9 += x14;
+                x4 = Integer.rotateLeft(x4 ^ x9, 12);
+                x3 += x4;
+                x14 = Integer.rotateLeft(x14 ^ x3, 8);
+                x9 += x14;
+                x4 = Integer.rotateLeft(x4 ^ x9, 7);
+            }
+
+            long seedLo = packInts(x0 + CONSTANT_0, x1 + CONSTANT_1);
+            long seedHi = packInts(x2 + CONSTANT_2, x3 + CONSTANT_3);
+            if ((seedLo | seedHi) != 0L) {
+                return factory.create(seedLo, seedHi);
+            }
+
+            seedLo = packInts(x4 + this.key0, x5 + this.key1);
+            seedHi = packInts(x6 + this.key2, x7 + this.key3);
+            if ((seedLo | seedHi) != 0L) {
+                return factory.create(seedLo, seedHi);
+            }
+
+            seedLo = packInts(x8 + this.key4, x9 + this.key5);
+            seedHi = packInts(x10 + this.key6, x11 + this.key7);
+            if ((seedLo | seedHi) != 0L) {
+                return factory.create(seedLo, seedHi);
+            }
+
+            seedLo = packInts(x12 + counter, x13 + nonce0);
+            seedHi = packInts(x14 + nonce1, x15 + nonce2);
+            return (seedLo | seedHi) == 0L ? null : factory.create(seedLo, seedHi);
+        }
+    }
+
+    private static int readIntLittleEndian(final byte[] input, final int offset) {
+        return (input[offset] & 0xFF)
+            | (input[offset + 1] & 0xFF) << 8
+            | (input[offset + 2] & 0xFF) << 16
+            | (input[offset + 3] & 0xFF) << 24;
+    }
+
+    private static long packInts(final int low, final int high) {
+        return Integer.toUnsignedLong(low) | Integer.toUnsignedLong(high) << Integer.SIZE;
+    }
+}

--- a/leaf-server/src/main/java/su/plo/matter/Globals.java
+++ b/leaf-server/src/main/java/su/plo/matter/Globals.java
@@ -1,7 +1,10 @@
 package su.plo.matter;
 
-import com.google.common.collect.Iterables;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.RandomSequence;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.RandomSupport;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
@@ -12,8 +15,15 @@ public class Globals {
     public static final int WORLD_SEED_LONGS = 16;
     public static final int WORLD_SEED_BITS = WORLD_SEED_LONGS * 64;
 
-    public static final long[] worldSeed = new long[WORLD_SEED_LONGS];
-    public static final ThreadLocal<Integer> dimension = ThreadLocal.withInitial(() -> 0);
+    private static final int CUSTOM_DIMENSION_ID = -1;
+    private static final DimensionSeed OVERWORLD_DIMENSION_SEED = new DimensionSeed(0, 0L, 0L);
+    private static final DimensionSeed NETHER_DIMENSION_SEED = new DimensionSeed(1, 0L, 0L);
+    private static final DimensionSeed END_DIMENSION_SEED = new DimensionSeed(2, 0L, 0L);
+    private static final ThreadLocal<long[]> WORLD_SEED = ThreadLocal.withInitial(() -> new long[WORLD_SEED_LONGS]);
+    private static final ThreadLocal<DimensionSeed> DIMENSION_SEED = ThreadLocal.withInitial(() -> OVERWORLD_DIMENSION_SEED);
+
+    public record DimensionSeed(int legacyId, long seedLo, long seedHi) {
+    }
 
     public enum Salt {
         UNDEFINED,
@@ -39,12 +49,29 @@ public class Globals {
     public static void setupGlobals(ServerLevel world) {
         if (!org.dreeam.leaf.config.modules.misc.SecureSeed.enabled) return;
 
-        long[] seed = world.getServer().getWorldGenSettings().options().featureSeed();
-        System.arraycopy(seed, 0, worldSeed, 0, WORLD_SEED_LONGS);
-        int worldIndex = Iterables.indexOf(world.getServer().levelKeys(), it -> it == world.dimension());
-        if (worldIndex == -1)
-            worldIndex = world.getServer().levelKeys().size(); // if we are in world construction it may not have been added to the map yet
-        dimension.set(worldIndex);
+        copyWorldSeed(world, WORLD_SEED.get());
+        DIMENSION_SEED.set(world.matter$dimensionSeed);
+    }
+
+    public static DimensionSeed createDimensionSeed(ResourceKey<Level> dimension) {
+        if (dimension == Level.OVERWORLD) return OVERWORLD_DIMENSION_SEED;
+        if (dimension == Level.NETHER) return NETHER_DIMENSION_SEED;
+        if (dimension == Level.END) return END_DIMENSION_SEED;
+
+        RandomSupport.Seed128bit seed = RandomSequence.seedForKey(dimension.identifier());
+        return new DimensionSeed(CUSTOM_DIMENSION_ID, seed.seedLo(), seed.seedHi());
+    }
+
+    static void copyWorldSeed(long[] destination) {
+        System.arraycopy(WORLD_SEED.get(), 0, destination, 0, WORLD_SEED_LONGS);
+    }
+
+    static void copyWorldSeed(ServerLevel world, long[] destination) {
+        System.arraycopy(world.worldGenSettings.options().featureSeed(), 0, destination, 0, WORLD_SEED_LONGS);
+    }
+
+    static DimensionSeed dimensionSeed() {
+        return DIMENSION_SEED.get();
     }
 
     public static long[] createRandomWorldSeed() {

--- a/leaf-server/src/main/java/su/plo/matter/HmacSha256RandomSource.java
+++ b/leaf-server/src/main/java/su/plo/matter/HmacSha256RandomSource.java
@@ -1,0 +1,191 @@
+package su.plo.matter;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import javax.crypto.Mac;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.BitRandomSource;
+import net.minecraft.world.level.levelgen.MarsagliaPolarGaussian;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+
+final class HmacSha256RandomSource implements BitRandomSource {
+    private static final int BLOCK_BITS = 256;
+    private final byte[] baseKey;
+    private byte[] streamKey;
+    private final byte[] block = new byte[TerrainCrypto.MASTER_SEED_BYTES];
+    private final MarsagliaPolarGaussian gaussianSource = new MarsagliaPolarGaussian(this);
+    private Mac blockMac;
+    private long counter;
+    private boolean exhausted;
+    private int bitIndex = BLOCK_BITS;
+
+    HmacSha256RandomSource(final byte[] key) {
+        if (key.length != TerrainCrypto.MASTER_SEED_BYTES) {
+            throw new IllegalArgumentException("HMAC random source key must be exactly " + TerrainCrypto.MASTER_SEED_BYTES + " bytes");
+        }
+        this.baseKey = key.clone();
+        this.streamKey = key.clone();
+        this.blockMac = TerrainHashing.createMac(this.streamKey);
+    }
+
+    @Override
+    public int next(final int bits) {
+        if (bits < 0 || bits > Integer.SIZE) {
+            throw new IllegalArgumentException("Bit count must be between 0 and " + Integer.SIZE + ": " + bits);
+        }
+
+        int remaining = bits;
+        int result = 0;
+        while (remaining > 0) {
+            this.ensureBlock();
+            int byteIndex = this.bitIndex >>> 3;
+            int bitOffset = this.bitIndex & 7;
+            int take = Math.min(remaining, Byte.SIZE - bitOffset);
+            int shift = Byte.SIZE - bitOffset - take;
+            int value = (this.block[byteIndex] & 0xFF) >>> shift & (1 << take) - 1;
+            result = result << take | value;
+            this.bitIndex += take;
+            remaining -= take;
+        }
+        return result;
+    }
+
+    @Override
+    public RandomSource fork() {
+        return new HmacSha256RandomSource(
+            TerrainHashing.derive(this.streamKey, TerrainHashing.FORK, this.consumeMasterSeed())
+        );
+    }
+
+    @Override
+    public PositionalRandomFactory forkPositional() {
+        return new HmacPositionalRandomFactory(
+            TerrainHashing.derive(this.streamKey, TerrainHashing.POSITIONAL_FORK, this.consumeMasterSeed())
+        );
+    }
+
+    @Override
+    public void setSeed(final long seed) {
+        this.streamKey = TerrainHashing.derive(this.baseKey, TerrainHashing.SET_SEED, TerrainHashing.longContext(seed));
+        this.blockMac = TerrainHashing.createMac(this.streamKey);
+        this.counter = 0L;
+        this.exhausted = false;
+        this.bitIndex = BLOCK_BITS;
+        this.gaussianSource.reset();
+    }
+
+    @Override
+    public double nextGaussian() {
+        return this.gaussianSource.nextGaussian();
+    }
+
+    @Override
+    public long nextLong() {
+        return (long) this.next(Integer.SIZE) << Integer.SIZE | Integer.toUnsignedLong(this.next(Integer.SIZE));
+    }
+
+    @Override
+    public void consumeCount(final int rounds) {
+        if (rounds <= 0) {
+            return;
+        }
+
+        long bits = (long) rounds * Integer.SIZE;
+        if (this.bitIndex < BLOCK_BITS) {
+            int available = BLOCK_BITS - this.bitIndex;
+            int consumed = (int) Math.min(bits, available);
+            this.bitIndex += consumed;
+            bits -= consumed;
+        }
+
+        if (bits >= BLOCK_BITS) {
+            long blocks = bits / BLOCK_BITS;
+            this.skipBlocks(blocks);
+            bits %= BLOCK_BITS;
+            this.bitIndex = BLOCK_BITS;
+        }
+
+        if (bits > 0L) {
+            this.ensureBlock();
+            this.bitIndex += (int) bits;
+        }
+    }
+
+    private void ensureBlock() {
+        if (this.bitIndex < BLOCK_BITS) {
+            return;
+        }
+        if (this.exhausted) {
+            throw new IllegalStateException("HMAC random source counter exhausted");
+        }
+
+        long blockCounter = this.counter;
+        if (blockCounter == -1L) {
+            this.exhausted = true;
+        } else {
+            this.counter = blockCounter + 1L;
+        }
+        TerrainHashing.deriveBlock(this.blockMac, blockCounter, this.block);
+        this.bitIndex = 0;
+    }
+
+    private void skipBlocks(final long blocks) {
+        if (blocks == 0L) {
+            return;
+        }
+        if (this.exhausted) {
+            throw new IllegalStateException("HMAC random source counter exhausted");
+        }
+
+        long nextCounter = this.counter + blocks;
+        if (Long.compareUnsigned(nextCounter, this.counter) < 0) {
+            if (nextCounter != 0L) {
+                throw new IllegalStateException("HMAC random source counter exhausted");
+            }
+            this.exhausted = true;
+        }
+        this.counter = nextCounter;
+    }
+
+    private byte[] consumeMasterSeed() {
+        ByteBuffer buffer = ByteBuffer.allocate(TerrainCrypto.MASTER_SEED_BYTES).order(ByteOrder.BIG_ENDIAN);
+        for (int i = 0; i < TerrainCrypto.MASTER_SEED_BYTES / Integer.BYTES; i++) {
+            buffer.putInt(this.next(Integer.SIZE));
+        }
+        return buffer.array();
+    }
+
+    private static final class HmacPositionalRandomFactory implements PositionalRandomFactory {
+        private final byte[] key;
+
+        private HmacPositionalRandomFactory(final byte[] key) {
+            this.key = key.clone();
+        }
+
+        @Override
+        public RandomSource at(final int x, final int y, final int z) {
+            return new HmacSha256RandomSource(
+                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_AT, TerrainHashing.positionContext(x, y, z))
+            );
+        }
+
+        @Override
+        public RandomSource fromHashOf(final String name) {
+            return new HmacSha256RandomSource(
+                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_HASH, TerrainHashing.stringContext(name))
+            );
+        }
+
+        @Override
+        public RandomSource fromSeed(final long seed) {
+            return new HmacSha256RandomSource(
+                TerrainHashing.derive(this.key, TerrainHashing.POSITIONAL_SEED, TerrainHashing.longContext(seed))
+            );
+        }
+
+        @Override
+        public void parityConfigString(final StringBuilder sb) {
+            sb.append("HmacSha256PositionalRandomFactory");
+        }
+    }
+}

--- a/leaf-server/src/main/java/su/plo/matter/TerrainCrypto.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainCrypto.java
@@ -1,0 +1,88 @@
+package su.plo.matter;
+
+import com.mojang.logging.LogUtils;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import org.dreeam.leaf.util.LeafConstants;
+import org.slf4j.Logger;
+
+public final class TerrainCrypto {
+    public static final int SCHEMA_VERSION = 1;
+    public static final String ALGORITHM = "hmac_sha256_v1";
+    public static final int MASTER_SEED_BYTES = 32;
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
+    private static final Codec<Serialized> SERIALIZED_CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.INT.fieldOf("schema_version").forGetter(Serialized::schemaVersion),
+        Codec.STRING.fieldOf("algorithm").forGetter(Serialized::algorithm),
+        Codec.STRING.fieldOf("master_seed").forGetter(Serialized::masterSeed)
+    ).apply(instance, Serialized::new));
+    private static final Codec<TerrainCrypto> STRICT_CODEC = SERIALIZED_CODEC.comapFlatMap(TerrainCrypto::decode, settings -> new Serialized(SCHEMA_VERSION, ALGORITHM, settings.masterSeedHex()));
+    public static final Codec<TerrainCrypto> CODEC = LeafConstants.DISABLE_SECURE_SEED_INTEGRITY_CHECK ? Codec.withAlternative(STRICT_CODEC, Codec.PASSTHROUGH, ignored -> recovered()) : STRICT_CODEC;
+
+    private final byte[] masterSeed;
+
+    private TerrainCrypto(final byte[] masterSeed) {
+        if (masterSeed.length != MASTER_SEED_BYTES) {
+            throw new IllegalArgumentException("Secure terrain master seed must be exactly " + MASTER_SEED_BYTES + " bytes");
+        }
+        this.masterSeed = masterSeed.clone();
+    }
+
+    public static TerrainCrypto random() {
+        byte[] seed = new byte[MASTER_SEED_BYTES];
+        SECURE_RANDOM.nextBytes(seed);
+        return new TerrainCrypto(seed);
+    }
+
+    private static TerrainCrypto recovered() {
+        LOGGER.error("Invalid secure terrain metadata was discarded because -D{}=true. A new terrain master seed will be generated and terrain seams may occur.", LeafConstants.DISABLE_SECURE_SEED_INTEGRITY_CHECK_FLAG);
+        return random();
+    }
+
+    public static TerrainCrypto fromHex(final String value) {
+        return new TerrainCrypto(parseMasterSeed(value));
+    }
+
+    private static DataResult<TerrainCrypto> decode(final Serialized serialized) {
+        if (serialized.schemaVersion != SCHEMA_VERSION) {
+            return DataResult.error(() -> "Unknown secure terrain schema version: " + serialized.schemaVersion);
+        }
+        if (!ALGORITHM.equals(serialized.algorithm)) {
+            return DataResult.error(() -> "Unknown secure terrain algorithm: " + serialized.algorithm);
+        }
+
+        try {
+            return DataResult.success(new TerrainCrypto(parseMasterSeed(serialized.masterSeed)));
+        } catch (IllegalArgumentException ex) {
+            return DataResult.error(ex::getMessage);
+        }
+    }
+
+    private static byte[] parseMasterSeed(final String value) {
+        if (value.length() != MASTER_SEED_BYTES * 2) {
+            throw new IllegalArgumentException("Secure terrain master seed must contain exactly " + (MASTER_SEED_BYTES * 2) + " hexadecimal characters");
+        }
+
+        try {
+            return HEX_FORMAT.parseHex(value);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Secure terrain master seed contains non-hexadecimal characters", ex);
+        }
+    }
+
+    public byte[] masterSeed() {
+        return this.masterSeed.clone();
+    }
+
+    public String masterSeedHex() {
+        return HEX_FORMAT.formatHex(this.masterSeed);
+    }
+
+    private record Serialized(int schemaVersion, String algorithm, String masterSeed) {
+    }
+}

--- a/leaf-server/src/main/java/su/plo/matter/TerrainCrypto.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainCrypto.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 
 public final class TerrainCrypto {
     public static final int SCHEMA_VERSION = 1;
-    public static final String ALGORITHM = "hmac_sha256_v1";
+    public static final String ALGORITHM = "blake2b_256_kdf_chacha12_v1";
     public static final int MASTER_SEED_BYTES = 32;
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();

--- a/leaf-server/src/main/java/su/plo/matter/TerrainCryptoContext.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainCryptoContext.java
@@ -1,0 +1,102 @@
+package su.plo.matter;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.RandomSupport;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import net.minecraft.world.level.levelgen.WorldOptions;
+import org.dreeam.leaf.config.modules.misc.SecureSeed;
+import org.jspecify.annotations.Nullable;
+
+public final class TerrainCryptoContext {
+    private final byte[] dimensionKey;
+
+    private TerrainCryptoContext(final byte[] dimensionKey) {
+        this.dimensionKey = dimensionKey.clone();
+    }
+
+    public static @Nullable TerrainCryptoContext create(final WorldOptions options, final ResourceKey<Level> dimension) {
+        if (!SecureSeed.isSecureTerrainEnabled()) {
+            return null;
+        }
+
+        TerrainCrypto terrainCrypto = options.terrainCrypto();
+        if (terrainCrypto == null) {
+            throw new IllegalStateException("Secure terrain is enabled but the world has no terrain master seed");
+        }
+
+        byte[] dimensionKey = TerrainHashing.derive(
+            terrainCrypto.masterSeed(),
+            TerrainHashing.DIMENSION,
+            TerrainHashing.stringContext(dimension.identifier().toString())
+        );
+        return new TerrainCryptoContext(dimensionKey);
+    }
+
+    public RandomSource initializationRandom(final String domain) {
+        return new HmacSha256RandomSource(this.domainKey(domain));
+    }
+
+    public PositionalRandomFactory runtimeFactory(final String domain) {
+        byte[] domainKey = this.domainKey(domain);
+        byte[] factoryKey = TerrainHashing.derive(domainKey, TerrainHashing.FAST_FACTORY, new byte[0]);
+        int attempt = 0;
+        while (true) {
+            long seedLo = TerrainHashing.readLong(factoryKey, 0);
+            long seedHi = TerrainHashing.readLong(factoryKey, Long.BYTES);
+            if ((seedLo | seedHi) != 0L) { // probability ~2^-128, how could that be possible
+                return new SecureRuntimeRandomFactory(seedLo, seedHi);
+            }
+
+            seedLo = TerrainHashing.readLong(factoryKey, Long.BYTES * 2);
+            seedHi = TerrainHashing.readLong(factoryKey, Long.BYTES * 3);
+            if ((seedLo | seedHi) != 0L) {
+                return new SecureRuntimeRandomFactory(seedLo, seedHi);
+            }
+
+            if (attempt == Integer.MAX_VALUE) {
+                throw new IllegalStateException("Unable to derive a non-zero secure terrain runtime seed");
+            }
+            factoryKey = TerrainHashing.derive(domainKey, TerrainHashing.FAST_FACTORY_RETRY, TerrainHashing.intContext(++attempt));
+        }
+    }
+
+    private byte[] domainKey(final String domain) {
+        return TerrainHashing.derive(this.dimensionKey, TerrainHashing.DOMAIN, TerrainHashing.stringContext(domain));
+    }
+
+    private static final class SecureRuntimeRandomFactory implements PositionalRandomFactory {
+        private final long seedLo;
+        private final long seedHi;
+
+        private SecureRuntimeRandomFactory(final long seedLo, final long seedHi) {
+            this.seedLo = seedLo;
+            this.seedHi = seedHi;
+        }
+
+        @Override
+        public RandomSource at(final int x, final int y, final int z) {
+            long positionalSeed = Mth.getSeed(x, y, z);
+            return new XoroshiroRandomSource(positionalSeed ^ this.seedLo, this.seedHi);
+        }
+
+        @Override
+        public RandomSource fromHashOf(final String name) {
+            RandomSupport.Seed128bit seed = RandomSupport.seedFromHashOf(name);
+            return new XoroshiroRandomSource(seed.xor(this.seedLo, this.seedHi));
+        }
+
+        @Override
+        public RandomSource fromSeed(final long seed) {
+            return new XoroshiroRandomSource(seed ^ this.seedLo, seed ^ this.seedHi);
+        }
+
+        @Override
+        public void parityConfigString(final StringBuilder sb) {
+            sb.append("SecureRuntimeRandomFactory");
+        }
+    }
+}

--- a/leaf-server/src/main/java/su/plo/matter/TerrainCryptoContext.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainCryptoContext.java
@@ -1,21 +1,19 @@
 package su.plo.matter;
 
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.PositionalRandomFactory;
-import net.minecraft.world.level.levelgen.RandomSupport;
-import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import net.minecraft.world.level.levelgen.WorldOptions;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import org.dreeam.leaf.config.modules.misc.SecureSeed;
 import org.jspecify.annotations.Nullable;
 
 public final class TerrainCryptoContext {
-    private final byte[] dimensionKey;
+    private final Blake2b.PreparedKey dimensionKey;
 
-    private TerrainCryptoContext(final byte[] dimensionKey) {
-        this.dimensionKey = dimensionKey.clone();
+    private TerrainCryptoContext(final Blake2b.PreparedKey dimensionKey) {
+        this.dimensionKey = dimensionKey;
     }
 
     public static @Nullable TerrainCryptoContext create(final WorldOptions options, final ResourceKey<Level> dimension) {
@@ -28,75 +26,57 @@ public final class TerrainCryptoContext {
             throw new IllegalStateException("Secure terrain is enabled but the world has no terrain master seed");
         }
 
-        byte[] dimensionKey = TerrainHashing.derive(
+        Blake2b.PreparedKey dimensionKey = TerrainHashing.derivePrepared(
             terrainCrypto.masterSeed(),
             TerrainHashing.DIMENSION,
-            TerrainHashing.stringContext(dimension.identifier().toString())
+            TerrainHashing.stringToBytes(dimension.identifier().toString())
         );
         return new TerrainCryptoContext(dimensionKey);
     }
 
     public RandomSource initializationRandom(final String domain) {
-        return new HmacSha256RandomSource(this.domainKey(domain));
+        return new Blake2bRandomSource(this.domainKey(domain));
     }
 
     public PositionalRandomFactory runtimeFactory(final String domain) {
-        byte[] domainKey = this.domainKey(domain);
-        byte[] factoryKey = TerrainHashing.derive(domainKey, TerrainHashing.FAST_FACTORY, new byte[0]);
-        int attempt = 0;
-        while (true) {
-            long seedLo = TerrainHashing.readLong(factoryKey, 0);
-            long seedHi = TerrainHashing.readLong(factoryKey, Long.BYTES);
-            if ((seedLo | seedHi) != 0L) { // probability ~2^-128, how could that be possible
-                return new SecureRuntimeRandomFactory(seedLo, seedHi);
-            }
-
-            seedLo = TerrainHashing.readLong(factoryKey, Long.BYTES * 2);
-            seedHi = TerrainHashing.readLong(factoryKey, Long.BYTES * 3);
-            if ((seedLo | seedHi) != 0L) {
-                return new SecureRuntimeRandomFactory(seedLo, seedHi);
-            }
-
-            if (attempt == Integer.MAX_VALUE) {
-                throw new IllegalStateException("Unable to derive a non-zero secure terrain runtime seed");
-            }
-            factoryKey = TerrainHashing.derive(domainKey, TerrainHashing.FAST_FACTORY_RETRY, TerrainHashing.intContext(++attempt));
-        }
+        return new SecureRuntimeRandomFactory(this.domainKey(domain));
     }
 
-    private byte[] domainKey(final String domain) {
-        return TerrainHashing.derive(this.dimensionKey, TerrainHashing.DOMAIN, TerrainHashing.stringContext(domain));
+    private Blake2b.PreparedKey domainKey(final String domain) {
+        return TerrainHashing.derivePrepared(this.dimensionKey, TerrainHashing.DOMAIN, TerrainHashing.stringToBytes(domain));
     }
 
     private static final class SecureRuntimeRandomFactory implements PositionalRandomFactory {
-        private final long seedLo;
-        private final long seedHi;
+        private static final Blake2b.Seed128Factory<RandomSource> BLAKE2B_XOROSHIRO_FACTORY = XoroshiroRandomSource::new;
+        private static final ChaCha12.Seed128Factory<RandomSource> CHACHA12_XOROSHIRO_FACTORY = XoroshiroRandomSource::new;
+        private final Blake2b.PreparedKey hashKey;
+        private final ChaCha12.PreparedKey positionKey;
+        private final ChaCha12.PreparedKey seedKey;
 
-        private SecureRuntimeRandomFactory(final long seedLo, final long seedHi) {
-            this.seedLo = seedLo;
-            this.seedHi = seedHi;
+        private SecureRuntimeRandomFactory(final Blake2b.PreparedKey key) {
+            this.hashKey = key;
+            this.positionKey = TerrainHashing.deriveChaChaKey(key, TerrainHashing.RUNTIME_AT);
+            this.seedKey = TerrainHashing.deriveChaChaKey(key, TerrainHashing.RUNTIME_SEED);
         }
 
         @Override
         public RandomSource at(final int x, final int y, final int z) {
-            long positionalSeed = Mth.getSeed(x, y, z);
-            return new XoroshiroRandomSource(positionalSeed ^ this.seedLo, this.seedHi);
+            return TerrainHashing.deriveRuntimePosition(this.positionKey, x, y, z, CHACHA12_XOROSHIRO_FACTORY);
         }
 
         @Override
         public RandomSource fromHashOf(final String name) {
-            RandomSupport.Seed128bit seed = RandomSupport.seedFromHashOf(name);
-            return new XoroshiroRandomSource(seed.xor(this.seedLo, this.seedHi));
+            return TerrainHashing.deriveRuntimeHash(this.hashKey, name, BLAKE2B_XOROSHIRO_FACTORY);
         }
 
         @Override
         public RandomSource fromSeed(final long seed) {
-            return new XoroshiroRandomSource(seed ^ this.seedLo, seed ^ this.seedHi);
+            return TerrainHashing.deriveRuntimeSeed(this.seedKey, seed, CHACHA12_XOROSHIRO_FACTORY);
         }
 
         @Override
         public void parityConfigString(final StringBuilder sb) {
-            sb.append("SecureRuntimeRandomFactory");
+            sb.append("SecureChaCha12RuntimeRandomFactory");
         }
     }
 }

--- a/leaf-server/src/main/java/su/plo/matter/TerrainHashing.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainHashing.java
@@ -1,0 +1,113 @@
+package su.plo.matter;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+final class TerrainHashing {
+    static final byte DIMENSION = 1;
+    static final byte DOMAIN = 2;
+    static final byte BLOCK = 3;
+    static final byte FORK = 4;
+    static final byte POSITIONAL_FORK = 5;
+    static final byte POSITIONAL_AT = 6;
+    static final byte POSITIONAL_HASH = 7;
+    static final byte POSITIONAL_SEED = 8;
+    static final byte SET_SEED = 9;
+    static final byte FAST_FACTORY = 10;
+    static final byte FAST_FACTORY_RETRY = 11;
+    private static final byte PROTOCOL_VERSION = 1;
+    private static final byte[] PROTOCOL_NAME = "LeafSecureWorldgen".getBytes(StandardCharsets.US_ASCII);
+
+    private TerrainHashing() {
+    }
+
+    static Mac createMac(final byte[] key) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac;
+        } catch (GeneralSecurityException ex) {
+            throw new IllegalStateException("HmacSHA256 is unavailable", ex);
+        }
+    }
+
+    static byte[] derive(final byte[] key, final byte tag, final byte[] context) {
+        return derive(createMac(key), tag, context);
+    }
+
+    static byte[] derive(final Mac mac, final byte tag, final byte[] context) {
+        mac.update(PROTOCOL_NAME);
+        mac.update((byte) 0);
+        mac.update(PROTOCOL_VERSION);
+        mac.update(tag);
+        updateInt(mac, context.length);
+        mac.update(context);
+        return mac.doFinal();
+    }
+
+    static void deriveBlock(final Mac mac, final long counter, final byte[] output) {
+        if (output.length < TerrainCrypto.MASTER_SEED_BYTES) {
+            throw new IllegalArgumentException("HMAC output buffer must contain at least " + TerrainCrypto.MASTER_SEED_BYTES + " bytes");
+        }
+
+        mac.update(PROTOCOL_NAME);
+        mac.update((byte) 0);
+        mac.update(PROTOCOL_VERSION);
+        mac.update(BLOCK);
+        updateInt(mac, Long.BYTES);
+        updateLong(mac, counter);
+        try {
+            mac.doFinal(output, 0);
+        } catch (GeneralSecurityException ex) {
+            throw new IllegalStateException("Unable to write HmacSHA256 output", ex);
+        }
+    }
+
+    private static void updateInt(final Mac mac, final int value) {
+        mac.update((byte) (value >>> 24));
+        mac.update((byte) (value >>> 16));
+        mac.update((byte) (value >>> 8));
+        mac.update((byte) value);
+    }
+
+    private static void updateLong(final Mac mac, final long value) {
+        mac.update((byte) (value >>> 56));
+        mac.update((byte) (value >>> 48));
+        mac.update((byte) (value >>> 40));
+        mac.update((byte) (value >>> 32));
+        mac.update((byte) (value >>> 24));
+        mac.update((byte) (value >>> 16));
+        mac.update((byte) (value >>> 8));
+        mac.update((byte) value);
+    }
+
+    static byte[] stringContext(final String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    static byte[] longContext(final long value) {
+        return ByteBuffer.allocate(Long.BYTES).order(ByteOrder.BIG_ENDIAN).putLong(value).array();
+    }
+
+    static byte[] intContext(final int value) {
+        return ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.BIG_ENDIAN).putInt(value).array();
+    }
+
+    static byte[] positionContext(final int x, final int y, final int z) {
+        return ByteBuffer.allocate(Integer.BYTES * 3)
+            .order(ByteOrder.BIG_ENDIAN)
+            .putInt(x)
+            .putInt(y)
+            .putInt(z)
+            .array();
+    }
+
+    static long readLong(final byte[] bytes, final int offset) {
+        return ByteBuffer.wrap(bytes, offset, Long.BYTES).order(ByteOrder.BIG_ENDIAN).getLong();
+    }
+
+}

--- a/leaf-server/src/main/java/su/plo/matter/TerrainHashing.java
+++ b/leaf-server/src/main/java/su/plo/matter/TerrainHashing.java
@@ -1,11 +1,6 @@
 package su.plo.matter;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 final class TerrainHashing {
     static final byte DIMENSION = 1;
@@ -17,97 +12,148 @@ final class TerrainHashing {
     static final byte POSITIONAL_HASH = 7;
     static final byte POSITIONAL_SEED = 8;
     static final byte SET_SEED = 9;
-    static final byte FAST_FACTORY = 10;
-    static final byte FAST_FACTORY_RETRY = 11;
+    static final byte RUNTIME_AT = 10;
+    static final byte RUNTIME_HASH = 11;
+    static final byte RUNTIME_SEED = 12;
+    static final byte RUNTIME_RETRY = 13;
     private static final byte PROTOCOL_VERSION = 1;
     private static final byte[] PROTOCOL_NAME = "LeafSecureWorldgen".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] EMPTY_CONTEXT = new byte[0];
+    private static final int GENERAL_HEADER_BYTES = PROTOCOL_NAME.length + 1 + 1 + 1 + Integer.BYTES;
 
     private TerrainHashing() {
     }
 
-    static Mac createMac(final byte[] key) {
-        try {
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(key, "HmacSHA256"));
-            return mac;
-        } catch (GeneralSecurityException ex) {
-            throw new IllegalStateException("HmacSHA256 is unavailable", ex);
+    static Blake2b.PreparedKey prepare(final byte[] key) {
+        return Blake2b.prepare(key);
+    }
+
+    static Blake2b.PreparedKey derivePrepared(final byte[] key, final byte tag, final byte[] context) {
+        return derivePrepared(prepare(key), tag, context);
+    }
+
+    static Blake2b.PreparedKey derivePrepared(final Blake2b.PreparedKey key, final byte tag, final byte[] context) {
+        byte[] derivedKey = derive(key, tag, context);
+        return prepare(derivedKey);
+    }
+
+    static Blake2b.PreparedKey derivePreparedLong(final Blake2b.PreparedKey key, final byte tag, final long value) {
+        byte[] derivedKey = new byte[Blake2b.OUTPUT_BYTES];
+        key.hashFixed16(fixedHeader(tag), Long.reverseBytes(value), derivedKey, 0);
+        return prepare(derivedKey);
+    }
+
+    static Blake2b.PreparedKey derivePreparedPosition(final Blake2b.PreparedKey key, final byte tag, final int x, final int y, final int z) {
+        byte[] derivedKey = new byte[Blake2b.OUTPUT_BYTES];
+        key.hashFixed16(positionHeader(tag, x), packInts(y, z), derivedKey, 0);
+        return prepare(derivedKey);
+    }
+
+    static ChaCha12.PreparedKey deriveChaChaKey(final Blake2b.PreparedKey key, final byte tag) {
+        return ChaCha12.prepare(derive(key, tag, EMPTY_CONTEXT));
+    }
+
+    static byte[] derive(final Blake2b.PreparedKey key, final byte tag, final byte[] context) {
+        byte[] message = buildHashFrame(tag, context);
+        byte[] output = new byte[Blake2b.OUTPUT_BYTES];
+        key.hash(message, output);
+        return output;
+    }
+
+    static void deriveBlock(final Blake2b.PreparedKey key, final long counter, final byte[] output) {
+        key.hashFixed16(fixedHeader(BLOCK), Long.reverseBytes(counter), output, 0);
+    }
+
+    static <R> R deriveRuntimePosition(final ChaCha12.PreparedKey key, final int x, final int y, final int z, final ChaCha12.Seed128Factory<R> factory) {
+        return key.derive(x, y, z, factory);
+    }
+
+    static <R> R deriveRuntimeSeed(final ChaCha12.PreparedKey key, final long seed, final ChaCha12.Seed128Factory<R> factory) {
+        return key.derive((int) seed, (int) (seed >>> Integer.SIZE), 0, factory);
+    }
+
+    static <R> R deriveRuntimeHash(final Blake2b.PreparedKey key, final String value, final Blake2b.Seed128Factory<R> factory) {
+        byte[] context = stringToBytes(value);
+        byte[] digest = derive(key, RUNTIME_HASH, context);
+        R result = createFromDigest(digest, factory);
+        if (result != null) {
+            return result;
+        }
+
+        int attempt = 0;
+        while (true) {
+            if (attempt == Integer.MAX_VALUE) {
+                throw new IllegalStateException("Unable to derive a non-zero secure terrain runtime hash seed");
+            }
+            attempt++;
+            byte[] retryContext = new byte[1 + Integer.BYTES + context.length];
+            retryContext[0] = RUNTIME_HASH;
+            writeInt(retryContext, 1, attempt);
+            System.arraycopy(context, 0, retryContext, 1 + Integer.BYTES, context.length);
+            digest = derive(key, RUNTIME_RETRY, retryContext);
+            result = createFromDigest(digest, factory);
+            if (result != null) {
+                return result;
+            }
         }
     }
 
-    static byte[] derive(final byte[] key, final byte tag, final byte[] context) {
-        return derive(createMac(key), tag, context);
-    }
-
-    static byte[] derive(final Mac mac, final byte tag, final byte[] context) {
-        mac.update(PROTOCOL_NAME);
-        mac.update((byte) 0);
-        mac.update(PROTOCOL_VERSION);
-        mac.update(tag);
-        updateInt(mac, context.length);
-        mac.update(context);
-        return mac.doFinal();
-    }
-
-    static void deriveBlock(final Mac mac, final long counter, final byte[] output) {
-        if (output.length < TerrainCrypto.MASTER_SEED_BYTES) {
-            throw new IllegalArgumentException("HMAC output buffer must contain at least " + TerrainCrypto.MASTER_SEED_BYTES + " bytes");
-        }
-
-        mac.update(PROTOCOL_NAME);
-        mac.update((byte) 0);
-        mac.update(PROTOCOL_VERSION);
-        mac.update(BLOCK);
-        updateInt(mac, Long.BYTES);
-        updateLong(mac, counter);
-        try {
-            mac.doFinal(output, 0);
-        } catch (GeneralSecurityException ex) {
-            throw new IllegalStateException("Unable to write HmacSHA256 output", ex);
-        }
-    }
-
-    private static void updateInt(final Mac mac, final int value) {
-        mac.update((byte) (value >>> 24));
-        mac.update((byte) (value >>> 16));
-        mac.update((byte) (value >>> 8));
-        mac.update((byte) value);
-    }
-
-    private static void updateLong(final Mac mac, final long value) {
-        mac.update((byte) (value >>> 56));
-        mac.update((byte) (value >>> 48));
-        mac.update((byte) (value >>> 40));
-        mac.update((byte) (value >>> 32));
-        mac.update((byte) (value >>> 24));
-        mac.update((byte) (value >>> 16));
-        mac.update((byte) (value >>> 8));
-        mac.update((byte) value);
-    }
-
-    static byte[] stringContext(final String value) {
+    static byte[] stringToBytes(final String value) {
         return value.getBytes(StandardCharsets.UTF_8);
     }
 
-    static byte[] longContext(final long value) {
-        return ByteBuffer.allocate(Long.BYTES).order(ByteOrder.BIG_ENDIAN).putLong(value).array();
+    private static byte[] buildHashFrame(final byte tag, final byte[] context) {
+        byte[] message = new byte[Math.addExact(GENERAL_HEADER_BYTES, context.length)];
+        System.arraycopy(PROTOCOL_NAME, 0, message, 0, PROTOCOL_NAME.length);
+        int offset = PROTOCOL_NAME.length;
+        message[offset++] = 0;
+        message[offset++] = PROTOCOL_VERSION;
+        message[offset++] = tag;
+        writeInt(message, offset, context.length);
+        System.arraycopy(context, 0, message, offset + Integer.BYTES, context.length);
+        return message;
     }
 
-    static byte[] intContext(final int value) {
-        return ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.BIG_ENDIAN).putInt(value).array();
+    private static long fixedHeader(final byte tag) {
+        return Byte.toUnsignedLong(PROTOCOL_VERSION) | Byte.toUnsignedLong(tag) << Byte.SIZE;
     }
 
-    static byte[] positionContext(final int x, final int y, final int z) {
-        return ByteBuffer.allocate(Integer.BYTES * 3)
-            .order(ByteOrder.BIG_ENDIAN)
-            .putInt(x)
-            .putInt(y)
-            .putInt(z)
-            .array();
+    private static long positionHeader(final byte tag, final int x) {
+        return fixedHeader(tag) | Integer.toUnsignedLong(Integer.reverseBytes(x)) << Integer.SIZE;
     }
 
-    static long readLong(final byte[] bytes, final int offset) {
-        return ByteBuffer.wrap(bytes, offset, Long.BYTES).order(ByteOrder.BIG_ENDIAN).getLong();
+    private static long packInts(final int first, final int second) {
+        return Integer.toUnsignedLong(Integer.reverseBytes(first))
+            | Integer.toUnsignedLong(Integer.reverseBytes(second)) << Integer.SIZE;
     }
 
+    private static <R> R createFromDigest(final byte[] digest, final Blake2b.Seed128Factory<R> factory) {
+        long seedLo = readLongLittleEndian(digest, 0);
+        long seedHi = readLongLittleEndian(digest, Long.BYTES);
+        if ((seedLo | seedHi) != 0L) {
+            return factory.create(seedLo, seedHi);
+        }
+
+        seedLo = readLongLittleEndian(digest, Long.BYTES * 2);
+        seedHi = readLongLittleEndian(digest, Long.BYTES * 3);
+        return (seedLo | seedHi) == 0L ? null : factory.create(seedLo, seedHi);
+    }
+
+    private static long readLongLittleEndian(final byte[] input, final int offset) {
+        return (input[offset] & 0xFFL)
+            | (input[offset + 1] & 0xFFL) << 8
+            | (input[offset + 2] & 0xFFL) << 16
+            | (input[offset + 3] & 0xFFL) << 24
+            | (input[offset + 4] & 0xFFL) << 32
+            | (input[offset + 5] & 0xFFL) << 40
+            | (input[offset + 6] & 0xFFL) << 48
+            | (input[offset + 7] & 0xFFL) << 56;
+    }
+
+    private static void writeInt(final byte[] output, final int offset, final int value) {
+        output[offset] = (byte) (value >>> 24);
+        output[offset + 1] = (byte) (value >>> 16);
+        output[offset + 2] = (byte) (value >>> 8);
+        output[offset + 3] = (byte) value;
+    }
 }

--- a/leaf-server/src/main/java/su/plo/matter/WorldgenCryptoRandom.java
+++ b/leaf-server/src/main/java/su/plo/matter/WorldgenCryptoRandom.java
@@ -1,13 +1,17 @@
 package su.plo.matter;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.levelgen.LegacyRandomSource;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.RandomSupport;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 @NullMarked
 public class WorldgenCryptoRandom extends WorldgenRandom {
@@ -16,6 +20,9 @@ public class WorldgenCryptoRandom extends WorldgenRandom {
     private static final long[] HASHED_ZERO_SEED = Hashing.hashWorldSeed(new long[Globals.WORLD_SEED_LONGS]);
     private static final ThreadLocal<long[]> LAST_SEEN_WORLD_SEED = ThreadLocal.withInitial(() -> new long[Globals.WORLD_SEED_LONGS]);
     private static final ThreadLocal<long[]> HASHED_WORLD_SEED = ThreadLocal.withInitial(() -> HASHED_ZERO_SEED);
+    private static final long POSITIONAL_AT_DOMAIN = 1L;
+    private static final long POSITIONAL_HASH_DOMAIN = 2L;
+    private static final long POSITIONAL_SEED_DOMAIN = 3L;
 
     private final long[] worldSeed = new long[Globals.WORLD_SEED_LONGS];
     private final long[] randomBits = new long[8];
@@ -33,12 +40,37 @@ public class WorldgenCryptoRandom extends WorldgenRandom {
         }
     }
 
+    private WorldgenCryptoRandom(long[] worldSeed, long input0, long input1, long input2, long domain) {
+        this(0, 0, null, 0);
+        System.arraycopy(worldSeed, 0, this.worldSeed, 0, this.worldSeed.length);
+        this.message[0] = input0;
+        this.message[1] = input1;
+        this.message[2] = input2;
+        this.message[3] = this.counter = 0;
+        this.message[4] = domain;
+        this.randomBitIndex = MAX_RANDOM_BIT_INDEX;
+    }
+
+    // Slime chunk checks can run without a worldgen ThreadLocal context, so snapshot the target level directly.
+    private WorldgenCryptoRandom(ServerLevel level, int x, int z, Globals.Salt typeSalt, long salt) {
+        this(0, 0, null, 0);
+        Globals.copyWorldSeed(level, this.worldSeed);
+        this.setSecureSeed(x, z, typeSalt, salt, Objects.requireNonNull(level.matter$dimensionSeed));
+    }
+
     public void setSecureSeed(int x, int z, Globals.Salt typeSalt, long salt) {
-        System.arraycopy(Globals.worldSeed, 0, this.worldSeed, 0, Globals.WORLD_SEED_LONGS);
+        Globals.copyWorldSeed(this.worldSeed);
+        this.setSecureSeed(x, z, typeSalt, salt, Globals.dimensionSeed());
+    }
+
+    private void setSecureSeed(int x, int z, Globals.Salt typeSalt, long salt, Globals.DimensionSeed dimensionSeed) {
         message[0] = ((long) x << 32) | ((long) z & 0xffffffffL);
-        message[1] = ((long) Globals.dimension.get() << 32) | (salt & 0xffffffffL);
+        message[1] = ((long) dimensionSeed.legacyId() << 32) | (salt & 0xffffffffL);
         message[2] = typeSalt.ordinal();
         message[3] = counter = 0;
+        message[4] = 0;
+        message[5] = dimensionSeed.seedLo();
+        message[6] = dimensionSeed.seedHi();
         randomBitIndex = MAX_RANDOM_BIT_INDEX;
     }
 
@@ -56,46 +88,63 @@ public class WorldgenCryptoRandom extends WorldgenRandom {
         Hashing.hash(message, randomBits, cachedInternalState, 64, true);
     }
 
+    private static long lowMask(int bits) {
+        return bits == Long.SIZE ? -1L : (1L << bits) - 1L;
+    }
+
     private long getBits(int count) {
+        if (count < 0 || count > Long.SIZE) {
+            throw new IllegalArgumentException("Bit count must be between 0 and " + Long.SIZE + ": " + count);
+        }
+
         if (randomBitIndex >= MAX_RANDOM_BIT_INDEX) {
             moreRandomBits();
             randomBitIndex -= MAX_RANDOM_BIT_INDEX;
         }
 
         int alignment = randomBitIndex & 63;
-        if ((randomBitIndex >>> 6) == ((randomBitIndex + count) >>> 6)) {
-            long result = (randomBits[randomBitIndex >>> 6] >>> alignment) & ((1L << count) - 1);
+        int availableBits = Long.SIZE - alignment;
+        long result;
+        if (count <= availableBits) {
+            result = (randomBits[randomBitIndex >>> 6] >>> alignment) & lowMask(count);
             randomBitIndex += count;
-            return result;
         } else {
-            long result = (randomBits[randomBitIndex >>> 6] >>> alignment) & ((1L << (64 - alignment)) - 1);
-            randomBitIndex += count;
+            result = (randomBits[randomBitIndex >>> 6] >>> alignment) & lowMask(availableBits);
+            randomBitIndex += availableBits;
             if (randomBitIndex >= MAX_RANDOM_BIT_INDEX) {
                 moreRandomBits();
                 randomBitIndex -= MAX_RANDOM_BIT_INDEX;
             }
-            alignment = randomBitIndex & 63;
-            result <<= alignment;
-            result |= (randomBits[randomBitIndex >>> 6] >>> (64 - alignment)) & ((1L << alignment) - 1);
 
-            return result;
+            int remainingBits = count - availableBits;
+            result |= (randomBits[randomBitIndex >>> 6] & lowMask(remainingBits)) << availableBits;
+            randomBitIndex += remainingBits;
+
         }
+        return result;
     }
 
     @Override
     public RandomSource fork() {
         WorldgenCryptoRandom fork = new WorldgenCryptoRandom(0, 0, null, 0);
 
-        System.arraycopy(Globals.worldSeed, 0, fork.worldSeed, 0, Globals.WORLD_SEED_LONGS);
-        fork.message[0] = this.message[0];
-        fork.message[1] = this.message[1];
-        fork.message[2] = this.message[2];
-        fork.message[3] = this.message[3];
+        System.arraycopy(this.worldSeed, 0, fork.worldSeed, 0, this.worldSeed.length);
+        System.arraycopy(this.randomBits, 0, fork.randomBits, 0, this.randomBits.length);
+        System.arraycopy(this.message, 0, fork.message, 0, this.message.length);
         fork.randomBitIndex = this.randomBitIndex;
         fork.counter = this.counter;
         fork.nextLong();
 
         return fork;
+    }
+
+    @Override
+    public PositionalRandomFactory forkPositional() {
+        long[] factorySeed = new long[Globals.WORLD_SEED_LONGS];
+        for (int i = 0; i < factorySeed.length; i++) {
+            factorySeed[i] = this.nextLong();
+        }
+        return new CryptoPositionalRandomFactory(factorySeed);
     }
 
     @Override
@@ -156,7 +205,36 @@ public class WorldgenCryptoRandom extends WorldgenRandom {
         super.setLargeFeatureWithSalt(worldSeed, regionX, regionZ, salt);
     }
 
-    public static RandomSource seedSlimeChunk(int chunkX, int chunkZ) {
-        return new WorldgenCryptoRandom(chunkX, chunkZ, Globals.Salt.SLIME_CHUNK, 0);
+    public static RandomSource seedSlimeChunk(ServerLevel level, int chunkX, int chunkZ) {
+        return new WorldgenCryptoRandom(level, chunkX, chunkZ, Globals.Salt.SLIME_CHUNK, 0);
+    }
+
+    private static final class CryptoPositionalRandomFactory implements PositionalRandomFactory {
+        private final long[] worldSeed;
+
+        private CryptoPositionalRandomFactory(long[] worldSeed) {
+            this.worldSeed = worldSeed;
+        }
+
+        @Override
+        public RandomSource at(int x, int y, int z) {
+            return new WorldgenCryptoRandom(this.worldSeed, x, y, z, POSITIONAL_AT_DOMAIN);
+        }
+
+        @Override
+        public RandomSource fromHashOf(String name) {
+            RandomSupport.Seed128bit seed = RandomSupport.seedFromHashOf(name);
+            return new WorldgenCryptoRandom(this.worldSeed, seed.seedLo(), seed.seedHi(), 0L, POSITIONAL_HASH_DOMAIN);
+        }
+
+        @Override
+        public RandomSource fromSeed(long seed) {
+            return new WorldgenCryptoRandom(this.worldSeed, seed, 0L, 0L, POSITIONAL_SEED_DOMAIN);
+        }
+
+        @Override
+        public void parityConfigString(StringBuilder sb) {
+            sb.append("CryptoPositionalRandomFactory");
+        }
     }
 }


### PR DESCRIPTION
1. Level loading order hash is unreliable and may vary on world load/unload
2. CraftChunk#isSlimeChunk may cause a sync load when secure seed is enabled
3. Mineshaft, buried treasure and the pillager outpost are not protected
4. Feature seeds of custom worlds are completely ignored
5. The mask of `getBits(64)` is zero and causing `nextLong` to keep producing zero
6. WorldgenCryptoRandom is not implementing positional random, Geode noise uses this

### New Feature

Blake2b & ChaCha12 terrain secure seed, each terrain generation domain is independent to others