### PR TITLE
Optimize SpreadingSnowyBlock light retrieval

### DIFF
--- a/leaf-server/minecraft-patches/features/0331-Optimize-SpreadingSnowyBlock-light-retrieval.patch
+++ b/leaf-server/minecraft-patches/features/0331-Optimize-SpreadingSnowyBlock-light-retrieval.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Optimize SpreadingSnowyBlock light retrieval
+
+1. Use the chunk we already get
+2. Skip blockLight once skyLight >= 9
+3. Short-circuit earlier at night
+
+diff --git a/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java b/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java
+index e859cc266fe385949a058b85fa6be9c69951d85b..11f4f97b8b3a41d9cc84e7d9a01dbd465687fe81 100644
+--- a/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java
++++ b/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java
+@@ -220,6 +220,16 @@ public final class StarLightInterface {
+         return this.hasBlockLight;
+     }
+ 
++    // Leaf start - Optimize SpreadingSnowyBlock light retrieval
++    public boolean isRawBrightnessAtLeast(final BlockPos pos, final int ambientDarkness, final int threshold, final ChunkAccess chunk) {
++        // short-circuit earlier without getSkyLightValue
++        if (15 - ambientDarkness >= threshold && this.getSkyLightValue(pos, chunk) - ambientDarkness >= threshold) {
++            return true;
++        }
++        return this.getBlockLightValue(pos, chunk) >= threshold;
++    }
++    // Leaf end - Optimize SpreadingSnowyBlock light retrieval
++
+     public int getSkyLightValue(final BlockPos blockPos, final ChunkAccess chunk) {
+         if (!this.hasSkyLight) {
+             return 0;
+diff --git a/net/minecraft/world/level/block/SpreadingSnowyBlock.java b/net/minecraft/world/level/block/SpreadingSnowyBlock.java
+index 9baee897cc10f0e11002c2340c69b63c54bdd6ec..b00c4ccc32406407dcafce92083cc1a7bfa4d03e 100644
+--- a/net/minecraft/world/level/block/SpreadingSnowyBlock.java
++++ b/net/minecraft/world/level/block/SpreadingSnowyBlock.java
+@@ -78,7 +78,12 @@ public abstract class SpreadingSnowyBlock extends SnowyBlock {
+                 // CraftBukkit end
+                 level.setBlockAndUpdate(pos, baseBlock.get().defaultBlockState());
+             } else {
+-                if (level.getMaxLocalRawBrightness(pos.above()) >= 9) {
++                // Leaf start - Optimize SpreadingSnowyBlock light retrieval
++                if (!level.getLightEngine().starlight$getLightEngine().isRawBrightnessAtLeast(pos.above(), level.getSkyDarken(), 9, cachedChunk)) {
++                    return;
++                }
++                if (true) {
++                // Leaf end - Optimize SpreadingSnowyBlock light retrieval
+                     BlockState defaultBlockState = this.defaultBlockState();
+ 
+                     for (int i = 0; i < 4; i++) {

--- a/leaf-server/minecraft-patches/features/0331-Optimize-SpreadingSnowyBlock-light-retrieval.patch
+++ b/leaf-server/minecraft-patches/features/0331-Optimize-SpreadingSnowyBlock-light-retrieval.patch
@@ -7,6 +7,17 @@ Subject: [PATCH] Optimize SpreadingSnowyBlock light retrieval
 2. Skip blockLight once skyLight >= 9
 3. Short-circuit earlier at night
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java b/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java
 index e859cc266fe385949a058b85fa6be9c69951d85b..11f4f97b8b3a41d9cc84e7d9a01dbd465687fe81 100644
 --- a/ca/spottedleaf/moonrise/patches/starlight/light/StarLightInterface.java


### PR DESCRIPTION
1. Use the chunk we already get
2. Skip blockLight once skyLight >= 9
3. Short-circuit earlier at night
<img width="718" height="203" alt="image" src="https://github.com/user-attachments/assets/cfe5e21e-128d-4421-b613-8e1cbeb8d05d" />
