### PR TITLE
Async tracker updates

### DIFF
--- a/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0274-Multithreaded-Tracker.patch
@@ -173,7 +173,7 @@ index afaed2c11ec1058c9f148362c3f657644e8e0e41..22c29547680b9e5882aca54a0342303d
      }
      // CraftBukkit end
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e15bc33be 100644
+index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..3706f0b352c376d9573a656c2a74d9e862bcc06d 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -1097,6 +1097,12 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -384,7 +384,7 @@ index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e
                  }
              }
          }
-@@ -1464,10 +1532,152 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+@@ -1464,10 +1532,137 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
              // Paper end - optimise entity tracker
          }
  
@@ -395,11 +395,8 @@ index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e
 +                this.lastChunkUpdate = -1L;
 +                this.lastTrackedChunk = null;
 +                for (final ServerPlayerConnection conn : this.seenBy()) {
-+                    if (this.seenBy.remove(conn)) {
-+                        ctx.stopSeenByPlayer(conn, this.entity);
-+                    }
++                    ctx.collectStopSeenByPlayer(conn, this);
 +                }
-+                this.seenByUpdated();
 +                return false;
 +            }
 +
@@ -409,7 +406,6 @@ index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e
 +            this.lastChunkUpdate = currChunkUpdate;
 +            this.lastTrackedChunk = chunk;
 +
-+            boolean updated = false;
 +            final double ex = this.entity.getX();
 +            final double ey = this.entity.getY();
 +            final double ez = this.entity.getZ();
@@ -435,33 +431,22 @@ index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e
 +                        && ChunkMap.this.isChunkTracked(player, eChunkX, eChunkZ)
 +                        && player.getBukkitEntity().canSeeChunkMapUpdatePlayer(this.entity.getBukkitEntity());
 +                    if (flag) {
-+                        if (this.seenBy.add(player.connection)) {
-+                            ctx.startSeenByPlayer(player.connection, this.serverEntity.entity, this.seenBy.size() == 1);
-+                            this.serverEntity.onPlayerAdd();
-+                            updated = true;
++                        if (!this.seenBy.contains(player.connection)) {
++                            ctx.collectStartSeenByPlayer(player.connection, this);
 +                        }
-+                    } else if (this.seenBy.remove(player.connection)) {
-+                        ctx.stopSeenByPlayer(player.connection, this.entity);
-+                        updated = true;
++                    } else if (this.seenBy.contains(player.connection)) {
++                        ctx.collectStopSeenByPlayer(player.connection, this);
 +                    }
 +                }
-+            }
-+            if (updated) {
-+                this.seenByUpdated();
 +            }
 +            if (!chunkStateChanged) {
 +                return this.seenBy().length != 0;
 +            }
-+            updated = false;
 +            for (final ServerPlayerConnection conn : this.seenBy()) {
 +                final ServerPlayer player = conn.getPlayer();
-+                if (!players.contains(player) && this.seenBy.remove(conn)) {
-+                    ctx.stopSeenByPlayer(conn, this.entity);
-+                    updated = true;
++                if (!players.contains(player)) {
++                    ctx.collectStopSeenByPlayer(conn, this);
 +                }
-+            }
-+            if (updated) {
-+                this.seenByUpdated();
 +            }
 +            return this.seenBy().length != 0;
 +        }
@@ -540,7 +525,7 @@ index 13c5ebb35cfe06636bcd0bcd06fc3ddbbfa0d711..20efc6e98aa017e9f54aa13ba82b8e6e
      }
  }
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec5545c7df69 100644
+index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..6e84a8a44bfeef4ecc3c3f6dcd9d4769ba97446f 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -53,11 +53,11 @@ public class ServerEntity {
@@ -837,15 +822,7 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
                          new ClientboundMoveMinecartPacket(
                              this.entity.getId(),
                              List.of(
-@@ -332,6 +333,7 @@ public class ServerEntity {
-     }
- 
-     public void removePairing(final ServerPlayer player) {
-+        if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled) { ((ServerLevel) this.entity.level()).leaf$asyncTracker.ctx().stopSeenByPlayer(player.connection, this.entity); return; } // Leaf - Multithreaded tracker
-         this.entity.stopSeenByPlayer(player);
-         player.connection.send(new ClientboundRemoveEntitiesPacket(this.entity.getId()));
-     }
-@@ -419,6 +421,7 @@ public class ServerEntity {
+@@ -419,6 +420,7 @@ public class ServerEntity {
          return Mth.unpackDegrees(this.lastSentYHeadRot);
      }
  
@@ -853,7 +830,7 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
      private void sendDirtyEntityData() {
          SynchedEntityData entityData = this.entity.getEntityData();
          List<SynchedEntityData.DataValue<?>> packedValues = entityData.packDirty();
-@@ -426,10 +429,12 @@ public class ServerEntity {
+@@ -426,10 +428,12 @@ public class ServerEntity {
              this.trackedDataValues = entityData.getNonDefaultValues();
              this.synchronizer.sendToTrackingPlayersAndSelf(new ClientboundSetEntityDataPacket(this.entity.getId(), packedValues));
          }
@@ -866,7 +843,7 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
                  // CraftBukkit start - Send scaled max health
                  if (this.entity instanceof ServerPlayer serverPlayer) {
                      serverPlayer.getBukkitEntity().injectScaledMaxHealth(attributes, false);
-@@ -442,6 +447,190 @@ public class ServerEntity {
+@@ -442,6 +446,190 @@ public class ServerEntity {
          }
      }
  
@@ -1058,7 +1035,7 @@ index 3ae5196e0a0fa5b8c8f590b3cf6345993c459e7c..5b7fe0ecf878b500cfd35ddf1349ec55
          void sendToTrackingPlayers(Packet<? super ClientGamePacketListener> packet);
  
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 58724d8f65898f7f532621fbae2cff4eb1796f80..231925545b6543004a0f6164bf73ee7139ad86f6 100644
+index e230f6c3723044add1595471f3b41fec13dde9b1..f8879a56495691aace1f4ee9310592440d8cdbc8 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -244,6 +244,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet

--- a/leaf-server/minecraft-patches/features/0290-Filter-ClientboundSetEntityMotionPacket.patch
+++ b/leaf-server/minecraft-patches/features/0290-Filter-ClientboundSetEntityMotionPacket.patch
@@ -25,7 +25,7 @@ The only entities needing this are:
 This filter helps keep unneeded packets reduced, but also ensures that we keep smooth visual gameplay
 
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 5b7fe0ecf878b500cfd35ddf1349ec5545c7df69..3ac852fab71d7814dda9fbc882db6f0f162b56ee 100644
+index 6e84a8a44bfeef4ecc3c3f6dcd9d4769ba97446f..fdb9d357d3d5529341203cdd3f3185bedb5ce3e8 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -226,7 +226,13 @@ public class ServerEntity {
@@ -43,7 +43,7 @@ index 5b7fe0ecf878b500cfd35ddf1349ec5545c7df69..3ac852fab71d7814dda9fbc882db6f0f
                              this.synchronizer.sendToTrackingPlayers(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
                          }
                      }
-@@ -563,7 +569,13 @@ public class ServerEntity {
+@@ -562,7 +568,13 @@ public class ServerEntity {
                                      new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement),
                                      new ClientboundProjectilePowerPacket(projectile.getId(), projectile.accelerationPower)
                                  )));

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
@@ -26,7 +26,7 @@ public final class AsyncTracker {
     public static final int QUEUE = 1024;
     public static final int MIN_CHUNK = 16;
     public static final int THREADS = MultithreadedTracker.threads;
-    public static final FixedThreadExecutor TRACKER_EXECUTOR = ENABLED ? new FixedThreadExecutor(
+    public static final @Nullable FixedThreadExecutor TRACKER_EXECUTOR = ENABLED ? new FixedThreadExecutor(
         THREADS,
         QUEUE,
         THREAD_NAME
@@ -102,7 +102,7 @@ public final class AsyncTracker {
     }
 
     public void onEntitiesTickEnd() {
-        Future<TrackerCtx> @org.jetbrains.annotations.Nullable [] task = this.fut;
+        Future<TrackerCtx>[] task = this.fut;
         TrackerCtx local = this.local;
         if (task == null) {
             return;
@@ -118,7 +118,7 @@ public final class AsyncTracker {
     }
 
     public void onTickEnd() {
-        Future<TrackerCtx> @org.jetbrains.annotations.Nullable [] task = this.fut;
+        Future<TrackerCtx>[] task = this.fut;
         TrackerCtx local = this.local;
         this.fut = null;
         handle(task, local);

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -279,7 +279,7 @@ public final class TrackerCtx {
             world.debugSynchronizers().dropEntity(entity);
             return;
         }
-        // Dimension changed
+        // Dimension changed or tracker doesn't match
         if (entity.level() != world || currentTracker != tracker) {
             return;
         }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -49,13 +49,12 @@ public final class TrackerCtx {
     private final ObjectArrayList<ChunkMap.TrackedEntity> resync = new ObjectArrayList<>();
     private final ObjectArrayList<ChunkMap.TrackedEntity> pluginEntity = new ObjectArrayList<>();
     private final ObjectArrayList<ChunkMap.TrackedEntity> syncAttributes = new ObjectArrayList<>();
-    private final ObjectArrayList<Entity> debugRegistration = new ObjectArrayList<>();
     private final ObjectArrayList<ChunkMap.TrackedEntity> updateData = new ObjectArrayList<>();
 
-    private record StopSeen(Entity e, ObjectArrayList<ServerPlayerConnection> q) {
+    private record StopSeen(ChunkMap.TrackedEntity tracker, ObjectArrayList<ServerPlayerConnection> q) {
     }
 
-    private record StartSeen(Entity e,
+    private record StartSeen(ChunkMap.TrackedEntity tracker,
                              ObjectArrayList<ServerPlayerConnection> q) {
     }
 
@@ -63,9 +62,9 @@ public final class TrackerCtx {
         this.world = world;
     }
 
-    public void stopSeenByPlayer(ServerPlayerConnection connection, Entity entity) {
-        if (stopSeen.isEmpty() || !stopSeen.getLast().e.equals(entity)) {
-            stopSeen.add(new StopSeen(entity, new ObjectArrayList<>()));
+    public void collectStopSeenByPlayer(ServerPlayerConnection connection, ChunkMap.TrackedEntity tracker) {
+        if (stopSeen.isEmpty() || stopSeen.getLast().tracker != tracker) {
+            stopSeen.add(new StopSeen(tracker, new ObjectArrayList<>()));
         }
         ObjectArrayList<ServerPlayerConnection> players = stopSeen.getLast().q;
         if (players.isEmpty() || players.getLast() != connection) {
@@ -73,14 +72,11 @@ public final class TrackerCtx {
         }
     }
 
-    public void startSeenByPlayer(ServerPlayerConnection connection, Entity entity, boolean flag) {
-        if (startSeen.isEmpty() || !startSeen.getLast().e.equals(entity)) {
-            startSeen.add(new StartSeen(entity, new ObjectArrayList<>()));
+    public void collectStartSeenByPlayer(ServerPlayerConnection connection, ChunkMap.TrackedEntity tracker) {
+        if (startSeen.isEmpty() || startSeen.getLast().tracker != tracker) {
+            startSeen.add(new StartSeen(tracker, new ObjectArrayList<>()));
         }
         startSeen.getLast().q.add(connection);
-        if (flag) {
-            debugRegistration.add(entity);
-        }
     }
 
 
@@ -132,7 +128,6 @@ public final class TrackerCtx {
         pluginEntity.addAll(other.pluginEntity);
         resync.addAll(other.resync);
         syncAttributes.addAll(other.syncAttributes);
-        debugRegistration.addAll(other.debugRegistration);
         updateData.addAll(other.updateData);
         return other.packets;
     }
@@ -144,7 +139,6 @@ public final class TrackerCtx {
         pluginEntity.clear();
         resync.clear();
         syncAttributes.clear();
-        debugRegistration.clear();
         updateData.clear();
         packets.clear();
     }
@@ -153,14 +147,6 @@ public final class TrackerCtx {
         if (!pluginEntity.isEmpty()) {
             for (ChunkMap.TrackedEntity tracker : pluginEntity) {
                 handlePlugin(tracker);
-            }
-        }
-
-        if (!debugRegistration.isEmpty()) {
-            for (Entity entity : debugRegistration) {
-                if (entity.moonrise$getTrackedEntity() != null && !entity.isRemoved()) {
-                    world.debugSynchronizers().registerEntity(entity);
-                }
             }
         }
 
@@ -200,27 +186,12 @@ public final class TrackerCtx {
         }
 
         flush(world, this.packets);
-        if (!startSeen.isEmpty()) {
-            for (StartSeen track : startSeen) {
-                Entity entity = track.e;
-                for (ServerPlayerConnection connection : track.q) {
-                    entity.startSeenByPlayer(connection.getPlayer());
-                }
-            }
-        }
-
         if (!stopSeen.isEmpty()) {
             for (StopSeen untrack : stopSeen) {
                 handleStopTrack(untrack);
             }
         }
         flush(world, this.packets);
-        for (StopSeen untrack : stopSeen) {
-            Entity entity = untrack.e;
-            for (ServerPlayerConnection connection : untrack.q) {
-                entity.stopSeenByPlayer(connection.getPlayer());
-            }
-        }
     }
 
     private static void handlePlugin(ChunkMap.TrackedEntity tracker) {
@@ -259,39 +230,76 @@ public final class TrackerCtx {
     }
 
     private void handleStartTrack(StartSeen startSeen, boolean callEvent) {
-        ChunkMap.TrackedEntity tracker = startSeen.e.moonrise$getTrackedEntity();
-        if (tracker == null) {
+        ChunkMap.TrackedEntity tracker = startSeen.tracker;
+        Entity entity = tracker.serverEntity.entity;
+
+        if (entity.isRemoved() || entity.level() != world || entity.moonrise$getTrackedEntity() != tracker) {
             return;
         }
         for (ServerPlayerConnection connection : startSeen.q) {
             ServerPlayer player = connection.getPlayer();
-            ObjectArrayList<Packet<? super ClientGamePacketListener>> list = new ObjectArrayList<>(4);
-            tracker.serverEntity.sendPairingData(player, list::add);
-            if (callEvent
-                && !new PlayerTrackEntityEvent(
-                player.getBukkitEntity(),
-                startSeen.e.getBukkitEntity()
-            ).callEvent()) {
-                continue;
-            } else if (player.level() != world) {
+            if (player == entity || player.level() != world) {
                 // do not send old entities if it changed dimension
                 continue;
             }
-            connection.send(new ClientboundBundlePacket(list)); // #startTrackingEntity call after #send
-            world.debugSynchronizers().startTrackingEntity(player, startSeen.e);
+            if (tracker.seenBy.add(connection)) {
+                tracker.seenByUpdated();
+                if (callEvent
+                    && !new PlayerTrackEntityEvent(
+                    player.getBukkitEntity(),
+                    entity.getBukkitEntity()
+                ).callEvent()) {
+                    tracker.serverEntity.onPlayerAdd();
+                    continue;
+                }
+                ObjectArrayList<Packet<? super ClientGamePacketListener>> list = new ObjectArrayList<>(4);
+
+                tracker.serverEntity.sendPairingData(player, list::add);
+                connection.send(new ClientboundBundlePacket(list)); // #startTrackingEntity call after #send
+                entity.startSeenByPlayer(player);
+
+                if (tracker.seenBy.size() == 1) {
+                    world.debugSynchronizers().registerEntity(entity);
+                }
+                world.debugSynchronizers().startTrackingEntity(player, entity);
+                tracker.serverEntity.onPlayerAdd();
+            }
         }
     }
 
     private void handleStopTrack(StopSeen untrack) {
-        ChunkMap.TrackedEntity tracker = untrack.e.moonrise$getTrackedEntity();
-        for (ServerPlayerConnection connection : untrack.q) {
-            if (tracker == null || !tracker.seenBy.contains(connection)) {
-                // client side will clean entities if it has changed dimension
-                send(connection, new ClientboundRemoveEntitiesPacket(untrack.e.getId()));
+        ChunkMap.TrackedEntity tracker = untrack.tracker;
+        Entity entity = tracker.serverEntity.entity;
+        ChunkMap.TrackedEntity currentTracker = entity.moonrise$getTrackedEntity();
+
+        if (currentTracker == null) {
+            for (ServerPlayerConnection connection : untrack.q) {
+                send(connection, new ClientboundRemoveEntitiesPacket(entity.getId()));
             }
+            world.debugSynchronizers().dropEntity(entity);
+            return;
         }
-        if (tracker == null || tracker.seenBy.isEmpty()) {
-            world.debugSynchronizers().dropEntity(untrack.e);
+        // Dimension changed
+        if (entity.level() != world || currentTracker != tracker) {
+            return;
+        }
+        boolean updated = false;
+        for (ServerPlayerConnection connection : untrack.q) {
+            ServerPlayer player = connection.getPlayer();
+            if (!tracker.seenBy.remove(connection)) {
+                continue;
+            }
+            entity.stopSeenByPlayer(player);
+            updated = true;
+
+            // client side will clean entities if it has changed dimension
+            send(connection, new ClientboundRemoveEntitiesPacket(entity.getId()));
+        }
+        if (updated) {
+            tracker.seenByUpdated();
+            if (tracker.seenBy.isEmpty()) {
+                world.debugSynchronizers().dropEntity(entity);
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

### 1. Sync `removePairing` and `seenBy` update
PremiumVanish+Protocollib's hybrid vanish mode requires calling `removePairing` synchronously to be able to send entity remove packet immediately, and following packets will be filtered by PremiumVanish+Protocollib.
Original send packets later in the async tracker will cause the entity remove packet to be filtered, so that a fake entity is left in other players' view.

Fixed https://github.com/Winds-Studio/Leaf/issues/806

### 2. Bind to tracker on collecting start/stop seen
See `ServerPlayer player = serverPlayer; // Paper - TODO - recreate instance` under `PlayerList#respawn` 
Paper currently reuses the player instance, but recreates the tracker instance on respawn. So binding to the tracker can avoid this inconsistency, as we have async tracker.
**But** this change should be removed once Paper implements their TODO, since no need at that time.

### 3. Cleanup nullness annotations
From https://github.com/Winds-Studio/Leaf/pull/805