### PR TITLE
Remove final modifier from optimize PalettedContainer#get

### DIFF
--- a/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
+++ b/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
@@ -3,9 +3,10 @@ From: hayanesuru <hayanesuru@outlook.jp>
 Date: Sat, 9 Aug 2025 14:59:34 +0900
 Subject: [PATCH] optimize PalettedContainer#get
 
+Note: do not add final modifier to these two methods added, reserved for super hacky plugins
 
 diff --git a/net/minecraft/world/level/chunk/PalettedContainer.java b/net/minecraft/world/level/chunk/PalettedContainer.java
-index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..e9b3e534cbe7eace3a041785187b09421bfe8395 100644
+index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..ad40c4e9a3f927ac2a0f22073abdaace4a616d16 100644
 --- a/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/net/minecraft/world/level/chunk/PalettedContainer.java
 @@ -29,6 +29,18 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
@@ -41,11 +42,11 @@ index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..e9b3e534cbe7eace3a041785187b0942
      }
  
 +    // Leaf start - optimize PalettedContainer#get
-+    public final PalettedContainer.Data<T> getData() {
++    public PalettedContainer.Data<T> getData() {
 +        return (PalettedContainer.Data<T>) DATA_HANDLE.getAcquire(this);
 +    }
 +
-+    public final T get(final PalettedContainer.Data<T> data, final int index) {
++    public T get(final PalettedContainer.Data<T> data, final int index) {
 +        return this.readPalette(data, data.storage.get(index));
 +    }
 +    // Leaf end - optimize PalettedContainer#get

--- a/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
+++ b/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
@@ -3,12 +3,14 @@ From: hayanesuru <hayanesuru@outlook.jp>
 Date: Sat, 9 Aug 2025 14:59:34 +0900
 Subject: [PATCH] optimize PalettedContainer#get
 
+Note: Some plugins may extend the PalettedContainer and delegate operations to the original container.
+Keeps leaf$getDataAcquire non-final, so they can override and redirect the access back.
 
 diff --git a/net/minecraft/world/level/chunk/PalettedContainer.java b/net/minecraft/world/level/chunk/PalettedContainer.java
-index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..5a63b728204a2beaf0b528760bd4a4579f254157 100644
+index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..4f8b137c70c2e717cda6c3323637df642a1af4f1 100644
 --- a/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/net/minecraft/world/level/chunk/PalettedContainer.java
-@@ -29,6 +29,18 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
+@@ -29,6 +28,18 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
      private final T @Nullable [] presetValues; // Paper - Anti-Xray - Add preset values
      //private final ThreadingDetector threadingDetector = new ThreadingDetector("PalettedContainer"); // Paper - unused
  
@@ -27,7 +29,7 @@ index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..5a63b728204a2beaf0b528760bd4a457
      public void acquire() {
          // this.threadingDetector.checkAndLock(); // Paper - disable this - use proper synchronization
      }
-@@ -86,7 +98,7 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
+@@ -86,7 +97,7 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
      }
  
      private T readPalette(final PalettedContainer.Data<T> data, final int paletteIdx) {
@@ -36,16 +38,16 @@ index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..5a63b728204a2beaf0b528760bd4a457
          if (palette == null) {
              return this.readPaletteSlow(data, paletteIdx);
          }
-@@ -246,9 +258,19 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
+@@ -246,9 +257,19 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
          return this.get(this.strategy.getIndex(x, y, z));
      }
  
 +    // Leaf start - optimize PalettedContainer#get
-+    public PalettedContainer.Data<T> getData() {
++    public PalettedContainer.Data<T> leaf$getDataAcquire() {
 +        return (PalettedContainer.Data<T>) DATA_HANDLE.getAcquire(this);
 +    }
 +
-+    public final T get(final PalettedContainer.Data<T> data, final int index) {
++    public final T leaf$getFromData(final PalettedContainer.Data<T> data, final int index) {
 +        return this.readPalette(data, data.storage.get(index));
 +    }
 +    // Leaf end - optimize PalettedContainer#get

--- a/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
+++ b/leaf-server/minecraft-patches/features/0258-optimize-PalettedContainer-get.patch
@@ -3,10 +3,9 @@ From: hayanesuru <hayanesuru@outlook.jp>
 Date: Sat, 9 Aug 2025 14:59:34 +0900
 Subject: [PATCH] optimize PalettedContainer#get
 
-Note: do not add final modifier to these two methods added, reserved for super hacky plugins
 
 diff --git a/net/minecraft/world/level/chunk/PalettedContainer.java b/net/minecraft/world/level/chunk/PalettedContainer.java
-index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..ad40c4e9a3f927ac2a0f22073abdaace4a616d16 100644
+index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..5a63b728204a2beaf0b528760bd4a4579f254157 100644
 --- a/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/net/minecraft/world/level/chunk/PalettedContainer.java
 @@ -29,6 +29,18 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer
@@ -46,7 +45,7 @@ index 26dbb9da7a7f50ec913b1226eff9e9ce6b4f3f12..ad40c4e9a3f927ac2a0f22073abdaace
 +        return (PalettedContainer.Data<T>) DATA_HANDLE.getAcquire(this);
 +    }
 +
-+    public T get(final PalettedContainer.Data<T> data, final int index) {
++    public final T get(final PalettedContainer.Data<T> data, final int index) {
 +        return this.readPalette(data, data.storage.get(index));
 +    }
 +    // Leaf end - optimize PalettedContainer#get

--- a/leaf-server/minecraft-patches/features/0329-reduce-PalettedContainer-lookup-in-collisions.patch
+++ b/leaf-server/minecraft-patches/features/0329-reduce-PalettedContainer-lookup-in-collisions.patch
@@ -17,7 +17,7 @@ prominent legal notice accompanying the corresponding source:
 Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java b/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
-index 54b2492c3ab6bf9ff52cec53dc4635f725f9eb4f..af99f97e1678ea6f94debebe89ec4a7ef21e8cd5 100644
+index 54b2492c3ab6bf9ff52cec53dc4635f725f9eb4f..e100d13ced1b6635188320ad908d6625c83c5d2f 100644
 --- a/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
 +++ b/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
 @@ -1980,6 +1980,14 @@ public final class CollisionUtil {
@@ -29,7 +29,7 @@ index 54b2492c3ab6bf9ff52cec53dc4635f725f9eb4f..af99f97e1678ea6f94debebe89ec4a7e
 +                        continue;
 +                    }
 +
-+                    final PalettedContainer.Data<BlockState> blocksData = blocks.getData();
++                    final PalettedContainer.Data<BlockState> blocksData = blocks.leaf$getDataAcquire();
 +                    // Leaf end - reduce PalettedContainer lookup in collisions
 +
                      for (int currY = minYIterate; currY <= maxYIterate; ++currY) {
@@ -40,7 +40,7 @@ index 54b2492c3ab6bf9ff52cec53dc4635f725f9eb4f..af99f97e1678ea6f94debebe89ec4a7e
                                  }
  
 -                                final BlockState blockData = blocks.get(localBlockIndex);
-+                                final BlockState blockData = blocks.get(blocksData, localBlockIndex); // Leaf - reduce PalettedContainer lookup in collisions
++                                final BlockState blockData = blocks.leaf$getFromData(blocksData, localBlockIndex); // Leaf - reduce PalettedContainer lookup in collisions
  
                                  if (((CollisionBlockState)blockData).moonrise$emptyContextCollisionShape()) {
                                      continue;


### PR DESCRIPTION
Some plugins may override PalettedContainer to implement features.

WHY DID THEY DO THIS?????