### PR TITLE
Cleanup optimized brain collections

### DIFF
--- a/leaf-server/minecraft-patches/features/0144-Replace-brain-with-optimized-collection.patch
+++ b/leaf-server/minecraft-patches/features/0144-Replace-brain-with-optimized-collection.patch
@@ -29,7 +29,7 @@ index c8185e32f7e4b2b4df959a571a7c4c80f5983986..cbb54e19819b04b6ee250b386d93876f
  
      public static <E extends LivingEntity> ActivityData<E> create(
 diff --git a/net/minecraft/world/entity/ai/Brain.java b/net/minecraft/world/entity/ai/Brain.java
-index 2b22bbfac4e324969e7cff368c690ee915d33a66..e810840bacb2d500ce29907db96e2abf810d451b 100644
+index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f5a85cce8 100644
 --- a/net/minecraft/world/entity/ai/Brain.java
 +++ b/net/minecraft/world/entity/ai/Brain.java
 @@ -37,14 +37,21 @@ import org.jspecify.annotations.Nullable;
@@ -100,26 +100,29 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..e810840bacb2d500ce29907db96e2abf
      }
  
      public boolean isActive(final Activity activity) {
-@@ -402,34 +416,95 @@ public class Brain<E extends LivingEntity> {
+@@ -402,34 +416,106 @@ public class Brain<E extends LivingEntity> {
      public void stopAll(final ServerLevel level, final E body) {
          long timestamp = body.level().getGameTime();
  
 -        for (BehaviorControl<? super E> behavior : this.getRunningBehaviors()) {
 -            behavior.doStop(level, body, timestamp);
 +        // Leaf start - Replace brain maps with optimized collection
-+        if (this.availableBehaviorsByPriorityArray.length != this.availableBehaviorsByPriority.size()) {
-+            this.availableBehaviorsByPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
++        var byPriorityArray = this.availableBehaviorsByPriorityArray;
++        if (byPriorityArray.length != this.availableBehaviorsByPriority.size()) {
++            byPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
++            this.availableBehaviorsByPriorityArray = byPriorityArray;
 +        }
-+        for (Map<Activity, Set<BehaviorControl<? super E>>> map : availableBehaviorsByPriorityArray) {
-+            var map1 = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) map;
-+            for (int index = 0, size = map1.size(); index < size; index++) {
-+                var behaviorControls = (org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) map1.v[index];
-+                var behaviorControlsRaw = behaviorControls.raw();
-+                for (int i = 0, size1 = behaviorControls.size(); i < size1; i++) {
-+                    BehaviorControl<? super E> behavior = behaviorControlsRaw[i];
++        for (Map<Activity, Set<BehaviorControl<? super E>>> byActivity : byPriorityArray) {
++            var behaviorsByActivity = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) byActivity;
++            final var behaviorSets = behaviorsByActivity.v;
++            for (int i = 0, size = behaviorsByActivity.size(); i < size; i++) {
++                var behaviorSet = (org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) behaviorSets[i];
++                final var behaviors = behaviorSet.raw();
++                for (int index = 0, count = behaviorSet.size(); index < count; index++) {
++                    BehaviorControl<? super E> behavior = behaviors[index];
 +                    if (behavior.getStatus() == Behavior.Status.RUNNING) {
 +                        behavior.doStop(level, body, timestamp);
-+                        behaviorControls.dec();
++                        behaviorSet.dec();
 +                    }
 +                }
 +            }
@@ -139,36 +142,41 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..e810840bacb2d500ce29907db96e2abf
 -                            behavior.tryStart(level, body, time);
 -                        }
 +        // Leaf start - Replace brain maps with optimized collection
-+        if (this.availableBehaviorsByPriorityArray.length != this.availableBehaviorsByPriority.size()) {
-+            this.availableBehaviorsByPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
++        var byPriorityArray = this.availableBehaviorsByPriorityArray;
++        if (byPriorityArray.length != this.availableBehaviorsByPriority.size()) {
++            byPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
++            this.availableBehaviorsByPriorityArray = byPriorityArray;
 +        }
-+        var aact = (org.dreeam.leaf.util.map.ActivityBitSet) this.activeActivities;
-+        if (activeBehaviors == EMPTY_BEHAVIOR_ARRAY || aact.unsetDirty()) {
-+            var list = it.unimi.dsi.fastutil.objects.ReferenceArrayList.wrap(activeBehaviors);
-+            list.clear();
-+            int activeSet = aact.bitSet();
-+            for (Map<Activity, Set<BehaviorControl<? super E>>> behavioursByActivities : availableBehaviorsByPriorityArray) {
-+                for (int index = 0; index < org.dreeam.leaf.util.RegistryTypeManager.ACTIVITY_SIZE; index++) {
-+                    if ((activeSet & (1 << index)) == 0) {
++        var activeActivities = (org.dreeam.leaf.util.map.ActivityBitSet) this.activeActivities;
++        var activeBehaviors = this.activeBehaviors;
++        if (activeBehaviors == EMPTY_BEHAVIOR_ARRAY || activeActivities.unsetDirty()) {
++            var activeBehaviorList = it.unimi.dsi.fastutil.objects.ReferenceArrayList.wrap(activeBehaviors);
++            activeBehaviorList.clear();
++            int mask = activeActivities.bitSet();
++            for (Map<Activity, Set<BehaviorControl<? super E>>> byActivity : byPriorityArray) {
++                var behaviorsByActivity = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) byActivity;
++                for (int id = 0; id < org.dreeam.leaf.util.RegistryTypeManager.ACTIVITY_SIZE; id++) {
++                    if ((mask & (1 << id)) == 0) {
 +                        continue;
 +                    }
-+                    var ele = ((org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) behavioursByActivities).getValue(index);
-+                    if (ele == null) {
++                    Set<BehaviorControl<? super E>> behaviorSet = behaviorsByActivity.getValue(id);
++                    if (behaviorSet == null) {
 +                        continue;
                      }
-+                    list.add((org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) ele);
++                    activeBehaviorList.add((org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) behaviorSet);
                  }
              }
-+            activeBehaviors = it.unimi.dsi.fastutil.objects.ObjectArrays.setLength(list.elements(), list.size());
++            activeBehaviors = it.unimi.dsi.fastutil.objects.ObjectArrays.setLength(activeBehaviorList.elements(), activeBehaviorList.size());
++            this.activeBehaviors = activeBehaviors;
          }
-+        for (int index = 0, size = activeBehaviors.length; index < size; index++) {
-+            var behaviorControls = activeBehaviors[index];
-+            var behaviorControlsRaw = behaviorControls.raw();
-+            for (int i = 0, size1 = behaviorControls.size(); i < size1; i++) {
-+                BehaviorControl<? super E> behavior = behaviorControlsRaw[i];
++        for (int i = 0; i < activeBehaviors.length; i++) {
++            var behaviorSet = activeBehaviors[i];
++            final var behaviors = behaviorSet.raw();
++            for (int index = 0, count = behaviorSet.size(); index < count; index++) {
++                BehaviorControl<? super E> behavior = behaviors[index];
 +                if (behavior.getStatus() == Behavior.Status.STOPPED) {
 +                    if (behavior.tryStart(level, body, time)) {
-+                        behaviorControls.inc();
++                        behaviorSet.inc();
 +                    }
 +                }
 +            }
@@ -182,23 +190,26 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..e810840bacb2d500ce29907db96e2abf
 -        for (BehaviorControl<? super E> behavior : this.getRunningBehaviors()) {
 -            behavior.tickOrStop(level, body, timestamp);
 +        // Leaf start - Replace brain maps with optimized collection
-+        if (this.availableBehaviorsByPriorityArray.length != this.availableBehaviorsByPriority.size()) {
-+            this.availableBehaviorsByPriorityArray = this.availableBehaviorsByPriority.values().toArray(new Map[0]);
++        var byPriorityArray = this.availableBehaviorsByPriorityArray;
++        if (byPriorityArray.length != this.availableBehaviorsByPriority.size()) {
++            byPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
++            this.availableBehaviorsByPriorityArray = byPriorityArray;
 +        }
-+        for (Map<Activity, Set<BehaviorControl<? super E>>> map : availableBehaviorsByPriorityArray) {
-+            var map1 = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) map;
-+            for (int index = 0, size = map1.size(); index < size; index++) {
-+                var behaviorControls = (org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) map1.v[index];
-+                if (!behaviorControls.running()) {
++        for (Map<Activity, Set<BehaviorControl<? super E>>> byActivity : byPriorityArray) {
++            var behaviorsByActivity = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) byActivity;
++            final var behaviorSets = behaviorsByActivity.v;
++            for (int i = 0, size = behaviorsByActivity.size(); i < size; i++) {
++                var behaviorSet = (org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) behaviorSets[i];
++                if (!behaviorSet.running()) {
 +                    continue;
 +                }
-+                BehaviorControl<? super E>[] behaviorControlsRaw = behaviorControls.raw();
-+                for (int i = 0, size1 = behaviorControls.size(); i < size1; i++) {
-+                    BehaviorControl<? super E> behavior = behaviorControlsRaw[i];
++                BehaviorControl<? super E>[] behaviors = behaviorSet.raw();
++                for (int index = 0, count = behaviorSet.size(); index < count; index++) {
++                    BehaviorControl<? super E> behavior = behaviors[index];
 +                    if (behavior.getStatus() == Behavior.Status.RUNNING) {
 +                        behavior.tickOrStop(level, body, timestamp);
 +                        if (behavior.getStatus() == Behavior.Status.STOPPED) {
-+                            behaviorControls.dec();
++                            behaviorSet.dec();
 +                        }
 +                    }
 +                }

--- a/leaf-server/minecraft-patches/features/0144-Replace-brain-with-optimized-collection.patch
+++ b/leaf-server/minecraft-patches/features/0144-Replace-brain-with-optimized-collection.patch
@@ -29,7 +29,7 @@ index c8185e32f7e4b2b4df959a571a7c4c80f5983986..cbb54e19819b04b6ee250b386d93876f
  
      public static <E extends LivingEntity> ActivityData<E> create(
 diff --git a/net/minecraft/world/entity/ai/Brain.java b/net/minecraft/world/entity/ai/Brain.java
-index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f5a85cce8 100644
+index 2b22bbfac4e324969e7cff368c690ee915d33a66..5f84ab70a41c4f30276cd895745ea773e671bea6 100644
 --- a/net/minecraft/world/entity/ai/Brain.java
 +++ b/net/minecraft/world/entity/ai/Brain.java
 @@ -37,14 +37,21 @@ import org.jspecify.annotations.Nullable;
@@ -61,16 +61,7 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
      private Activity defaultActivity = Activity.IDLE;
      private long lastScheduleUpdate = -9999L;
  
-@@ -99,6 +106,8 @@ public class Brain<E extends LivingEntity> {
- 
-         this.setCoreActivities(ImmutableSet.of(Activity.CORE));
-         this.useDefaultActivity();
-+
-+        ((it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap<MemoryModuleType<?>, MemorySlot<?>>) this.memories).trim(); // Leaf - Replace brain maps with optimized collection
-     }
- 
-     private void registerMemory(final MemoryModuleType<?> memoryType) {
-@@ -153,6 +162,8 @@ public class Brain<E extends LivingEntity> {
+@@ -153,6 +160,8 @@ public class Brain<E extends LivingEntity> {
  
      public void clearMemories() {
          this.memories.values().forEach(MemorySlot::clear);
@@ -79,7 +70,7 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
      }
  
      public <U> void eraseMemory(final MemoryModuleType<U> type) {
-@@ -367,15 +378,18 @@ public class Brain<E extends LivingEntity> {
+@@ -367,15 +376,18 @@ public class Brain<E extends LivingEntity> {
              }
  
              this.availableBehaviorsByPriority
@@ -100,7 +91,7 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
      }
  
      public boolean isActive(final Activity activity) {
-@@ -402,34 +416,106 @@ public class Brain<E extends LivingEntity> {
+@@ -402,34 +414,106 @@ public class Brain<E extends LivingEntity> {
      public void stopAll(final ServerLevel level, final E body) {
          long timestamp = body.level().getGameTime();
  
@@ -111,7 +102,7 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
 +        if (byPriorityArray.length != this.availableBehaviorsByPriority.size()) {
 +            byPriorityArray = this.availableBehaviorsByPriority.values().toArray(EMPTY_MAP_ARRAY);
 +            this.availableBehaviorsByPriorityArray = byPriorityArray;
-+        }
+         }
 +        for (Map<Activity, Set<BehaviorControl<? super E>>> byActivity : byPriorityArray) {
 +            var behaviorsByActivity = (org.dreeam.leaf.util.map.ActivityArrayMap<Set<BehaviorControl<? super E>>>) byActivity;
 +            final var behaviorSets = behaviorsByActivity.v;
@@ -126,7 +117,7 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
 +                    }
 +                }
 +            }
-         }
++        }
 +        // Leaf end - Replace brain maps with optimized collection
      }
  
@@ -162,13 +153,13 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
 +                    Set<BehaviorControl<? super E>> behaviorSet = behaviorsByActivity.getValue(id);
 +                    if (behaviorSet == null) {
 +                        continue;
-                     }
++                    }
 +                    activeBehaviorList.add((org.dreeam.leaf.util.map.BehaviorControlArraySet<? super E>) behaviorSet);
-                 }
-             }
++                }
++            }
 +            activeBehaviors = it.unimi.dsi.fastutil.objects.ObjectArrays.setLength(activeBehaviorList.elements(), activeBehaviorList.size());
 +            this.activeBehaviors = activeBehaviors;
-         }
++        }
 +        for (int i = 0; i < activeBehaviors.length; i++) {
 +            var behaviorSet = activeBehaviors[i];
 +            final var behaviors = behaviorSet.raw();
@@ -177,10 +168,10 @@ index 2b22bbfac4e324969e7cff368c690ee915d33a66..c4691592dab5ccee20c31949bbc5dc3f
 +                if (behavior.getStatus() == Behavior.Status.STOPPED) {
 +                    if (behavior.tryStart(level, body, time)) {
 +                        behaviorSet.inc();
-+                    }
-+                }
-+            }
-+        }
+                     }
+                 }
+             }
+         }
 +        // Leaf end - Replace brain maps with optimized collection
      }
  

--- a/leaf-server/minecraft-patches/features/0332-Lithium-Reduce-Brain-memories-lookup.patch
+++ b/leaf-server/minecraft-patches/features/0332-Lithium-Reduce-Brain-memories-lookup.patch
@@ -20,7 +20,7 @@ As part of: Lithium (https://github.com/CaffeineMC/lithium)
 Licensed under: LGPL-3.0-only (https://www.gnu.org/licenses/lgpl-3.0.html)
 
 diff --git a/net/minecraft/world/entity/ai/Brain.java b/net/minecraft/world/entity/ai/Brain.java
-index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae646d9556cd 100644
+index 5f84ab70a41c4f30276cd895745ea773e671bea6..d37c01f04f9a7c112ad857fcbeabcbff8bb6c874 100644
 --- a/net/minecraft/world/entity/ai/Brain.java
 +++ b/net/minecraft/world/entity/ai/Brain.java
 @@ -35,8 +35,9 @@ import net.minecraft.world.entity.schedule.Activity;
@@ -34,7 +34,7 @@ index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae64
      // Leaf start - Replace brain maps with optimized collection
      private final Map<MemoryModuleType<?>, MemorySlot<?>> memories = new it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap<>();
      private final Map<SensorType<? extends Sensor<? super E>>, Sensor<? super E>> sensors = new it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap<>();
-@@ -112,6 +113,7 @@ public class Brain<E extends LivingEntity> {
+@@ -110,6 +111,7 @@ public class Brain<E extends LivingEntity> {
  
      private void registerMemory(final MemoryModuleType<?> memoryType) {
          this.memories.putIfAbsent(memoryType, MemorySlot.create());
@@ -42,7 +42,7 @@ index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae64
      }
  
      public Brain() {
-@@ -164,11 +166,13 @@ public class Brain<E extends LivingEntity> {
+@@ -162,11 +164,13 @@ public class Brain<E extends LivingEntity> {
          this.memories.values().forEach(MemorySlot::clear);
          this.availableBehaviorsByPriorityArray = EMPTY_MAP_ARRAY; // Leaf - Replace brain maps with optimized collection
          this.activeBehaviors = EMPTY_BEHAVIOR_ARRAY; // Leaf - Replace brain maps with optimized collection
@@ -56,7 +56,7 @@ index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae64
              slot.clear();
          }
      }
-@@ -202,8 +206,10 @@ public class Brain<E extends LivingEntity> {
+@@ -200,8 +204,10 @@ public class Brain<E extends LivingEntity> {
              }
  
              if (value == null) {
@@ -67,7 +67,7 @@ index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae64
                  slot.set(value, tileToLive);
              }
          }
-@@ -217,8 +223,10 @@ public class Brain<E extends LivingEntity> {
+@@ -215,8 +221,10 @@ public class Brain<E extends LivingEntity> {
              }
  
              if (value == null) {
@@ -78,7 +78,7 @@ index e810840bacb2d500ce29907db96e2abf810d451b..8bb7ad63ecb73ec44a9bf7dc3441ae64
                  slot.set(value);
              }
          }
-@@ -410,8 +418,30 @@ public class Brain<E extends LivingEntity> {
+@@ -408,8 +416,30 @@ public class Brain<E extends LivingEntity> {
      }
  
      private void forgetOutdatedMemories() {


### PR DESCRIPTION
## Changes

### 1. Rename local vars to be more standard and readable
   Replaced names like `size1`, `map1`.
   Some naming suggestions refer to the Codex; let me know which names we should keep original one or which can still be improved (

### 2. Use local vars for instance variables to fix IOOB
  Fixed https://discord.com/channels/1145991395388162119/1469315324502605854
  Use the local var to store these instance field arrays to avoid iterating over them directly. In `Brain#clearMemories`, we clear these arrays by replacing them with the empty array, so we may get IOOB during iteration, since the array is replaced.