### PR TITLE
Optimize despawn tree building

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/world/DespawnMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/DespawnMap.java
@@ -53,6 +53,11 @@ public final class DespawnMap implements Consumer<Entity> {
                 fallback = true;
             }
         }
+        // Leaf - early exit before expensive work when falling back to vanilla
+        this.difficultyIsPeaceful = world.getDifficulty() == Difficulty.PEACEFUL;
+        if (fallback) {
+            return false;
+        }
         for (int i = 0; i < CATEGORIES.length; i++) {
             if (sort[i] > 0.0) {
                 sort[i] = sort[i] * sort[i];
@@ -80,13 +85,8 @@ public final class DespawnMap implements Consumer<Entity> {
             }
         }
         tree.build(new double[][]{playerX, playerY, playerZ}, new int[i]);
-        this.difficultyIsPeaceful = world.getDifficulty() == Difficulty.PEACEFUL;
-        if (fallback) {
-            return false;
-        } else {
-            entityTickList.forEach(this);
-            return true;
-        }
+        entityTickList.forEach(this);
+        return true;
     }
 
     private boolean checkDespawn(final Entity entity) {

--- a/leaf-server/src/main/java/org/dreeam/leaf/world/DespawnMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/DespawnMap.java
@@ -53,8 +53,9 @@ public final class DespawnMap implements Consumer<Entity> {
                 fallback = true;
             }
         }
-        // Leaf - early exit before expensive work when falling back to vanilla
+
         this.difficultyIsPeaceful = world.getDifficulty() == Difficulty.PEACEFUL;
+
         if (fallback) {
             return false;
         }


### PR DESCRIPTION
Return early when falling back to vanilla in DespawnMap to avoid expensive work. Move difficultyIsPeaceful assignment before the fallback check and short-circuit if fallback is true, preventing tree.build and entity iteration. Removes duplicate assignment and redundant conditional; no behavioral change aside from skipping unnecessary CPU work when using the fallback.