### PR TITLE
Optimize attribute update syncing

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -333,6 +333,9 @@ public final class TrackerCtx {
         ObjectArrayList<ClientboundUpdateAttributesPacket.AttributeSnapshot> attributes;
         if (attributeMap.attributes instanceof AttributeInstanceArrayMap map) {
             int[] ids = attributeMap.getAttributesToSyncIds();
+            if (ids.length == 0) {
+                return;
+            }
             attributes = new ObjectArrayList<>(ids.length);
             for (int attributeIdx : ids) {
                 AttributeInstance instance = map.getInstance(attributeIdx);
@@ -347,6 +350,9 @@ public final class TrackerCtx {
             }
         } else {
             Set<AttributeInstance> toSync = attributeMap.getAttributesToSync();
+            if (toSync.isEmpty()) {
+                return;
+            }
             attributes = new ObjectArrayList<>(toSync.size());
             for (AttributeInstance instance : toSync) {
                 if (instance == null) {


### PR DESCRIPTION
Skip empty attribute update packets.

When a tracker is queued only because entity data is dirty, no attributes may need to be synced. Avoid creating and sending an empty ClientboundUpdateAttributesPacket in that case.

This keeps the entity data update path unchanged and only skips unnecessary attribute packet creation and sending.